### PR TITLE
fix reown-swift.podspec

### DIFF
--- a/reown-swift.podspec
+++ b/reown-swift.podspec
@@ -116,7 +116,7 @@ Pod::Spec.new do |spec|
     ss.source_files = 'Sources/WalletConnectRelay/**/*.{h,m,swift}'
     ss.dependency 'reown-swift/WalletConnectJWT'
     ss.resource_bundles = {
-      'WalletConnect_WalletConnectRelay' => [
+      'reown_WalletConnectRelay' => [
          'Sources/WalletConnectRelay/PackageConfig.json'
       ]
     }


### PR DESCRIPTION
# Description

<!--
Please include:
* summary of the changes and the related issue
* relevant motivation and context
-->

Resolves # (issue)
The resource bundle name is error, it will be crashed in `BundleFinder.swift`

```swift
extension Foundation.Bundle {
    /// Returns the resource bundle associated with the current Swift module.
    static var resourceBundle: Bundle = {
        let bundleName = "reown_WalletConnectRelay"
        let candidates = [
            // Bundle should be present here when the package is linked into an App.
            Bundle.main.resourceURL,
            // Bundle should be present here when the package is linked into a framework.
            Bundle(for: BundleFinder.self).resourceURL,
            // For command-line tools.
            Bundle.main.bundleURL,
            // Bundle should be present here when running tests.
            Bundle(for: BundleFinder.self).resourceURL?
                .deletingLastPathComponent()
                .deletingLastPathComponent()
                .deletingLastPathComponent(),
            // Other possibilities
            Bundle(for: BundleFinder.self).resourceURL?
                .deletingLastPathComponent()
                .deletingLastPathComponent(),
        ]

        for candidate in candidates {
            let bundlePath = candidate?.appendingPathComponent(bundleName + ".bundle")
            if let bundle = bundlePath.flatMap(Bundle.init(url:)) {
                return bundle
            }
        }

        // If we can't find the bundle, fall back to the module bundle if available
        #if SWIFT_PACKAGE
        return Bundle.module
        #else
        return Bundle(for: BundleFinder.self)
        #endif
    }()
}
```


## How Has This Been Tested?

<!--
Please:
* describe the tests that you ran to verify your changes.
* provide instructions so we can reproduce.
-->

<!-- If valid for smoke test on feature add screenshots -->

## Due Dilligence

* [ ] Breaking change
* [ ] Requires a documentation update
