### PR TITLE
Update Yttrium to 0.9.7

### DIFF
--- a/Example/ExampleApp.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Example/ExampleApp.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -277,7 +277,7 @@
         "state": {
           "branch": null,
           "revision": "f6566a2b028ae60746254298ce1d5ba822ca5388",
-          "version": "0.9.0"
+          "version": "0.9.7"
         }
       }
     ]

--- a/Package.resolved
+++ b/Package.resolved
@@ -61,7 +61,7 @@
         "state": {
           "branch": null,
           "revision": "f6566a2b028ae60746254298ce1d5ba822ca5388",
-          "version": "0.9.0"
+          "version": "0.9.7"
         }
       }
     ]

--- a/Package.swift
+++ b/Package.swift
@@ -27,7 +27,7 @@ func buildYttriumWrapperTarget() -> Target {
             path: "Sources/YttriumWrapper"
         )
     } else {
-        dependencies.append(.package(url: "https://github.com/reown-com/yttrium", .exact("0.9.0")))
+        dependencies.append(.package(url: "https://github.com/reown-com/yttrium", .exact("0.9.7")))
         return .target(
             name: "YttriumWrapper",
             dependencies: [.product(name: "Yttrium", package: "yttrium")],

--- a/reown-swift.podspec
+++ b/reown-swift.podspec
@@ -28,7 +28,7 @@ spec.pod_target_xcconfig = {
 
   spec.subspec 'WalletKit' do |ss|
     ss.source_files = 'Sources/ReownWalletKit/**/*.{h,m,swift}'
-    ss.dependency 'YttriumWrapper', '0.9.0'
+    ss.dependency 'YttriumWrapper', '0.9.7'
     ss.dependency 'reown-swift/WalletConnectSign'
     ss.dependency 'reown-swift/WalletConnectPush'
     ss.dependency 'reown-swift/WalletConnectVerify'
@@ -80,7 +80,7 @@ spec.pod_target_xcconfig = {
   spec.subspec 'WalletConnectSigner' do |ss|
     ss.source_files = 'Sources/WalletConnectSigner/**/*.{h,m,swift}'
     ss.dependency 'reown-swift/WalletConnectNetworking'
-    ss.dependency 'YttriumWrapper', '0.9.0'
+    ss.dependency 'YttriumWrapper', '0.9.7'
   end
 
   spec.subspec 'WalletConnectIdentity' do |ss|


### PR DESCRIPTION
## Summary
- update `Yttrium` Swift Package dependency to `0.9.7`
- bump Yttrium version in the CocoaPods spec
- refresh resolved package versions for the main library and Example app

## Testing
- `swift test` *(fails: Failed to clone repository https://github.com/WalletConnect/QRCode)*