### PR TITLE
feat: implement primary session management

### DIFF
--- a/Claude.MD
+++ b/Claude.MD
@@ -1,0 +1,105 @@
+# Reown Swift - WalletKit & AppKit
+
+## Project Overview
+This is the Swift implementation of WalletKit and AppKit for native iOS applications. The project is developed by Reown (formerly WalletConnect) and provides a comprehensive SDK for integrating Web3 wallet connectivity and decentralized app functionality into iOS applications.
+
+## Key Components
+
+### Core Libraries
+- **ReownWalletKit**: The main wallet integration SDK
+- **ReownAppKit**: Framework for building decentralized apps with wallet connectivity
+- **WalletConnectSign**: Handles signing operations and session management
+- **WalletConnectPairing**: Manages pairing between wallets and dapps
+- **WalletConnectNetworking**: Network layer for WalletConnect protocol
+- **WalletConnectRelay**: WebSocket relay implementation
+- **WalletConnectVerify**: Verification and attestation services
+- **WalletConnectPush**: Push notification support
+- **WalletConnectIdentity**: Identity management
+- **ReownRouter**: Routing functionality
+
+### Supporting Libraries
+- **WalletConnectKMS**: Key Management Service
+- **WalletConnectJWT**: JWT token handling
+- **WalletConnectUtils**: Common utilities
+- **WalletConnectSigner**: Cryptographic signing operations
+- **HTTPClient**: HTTP networking client
+- **JSONRPC**: JSON-RPC protocol implementation
+- **Database**: SQLite database wrapper
+- **Events**: Event tracking and analytics
+- **Commons**: Common types and extensions
+
+### UI Components
+- **ReownAppKitUI**: UI components for AppKit
+- **ReownAppKitBackport**: Backward compatibility layer for older iOS versions
+
+## Technical Details
+
+### Platform Requirements
+- iOS 13.0+
+- macOS 11.0+
+- tvOS 13.0+
+- Swift 5.5+
+- Xcode 13+
+
+### Dependencies
+- QRCode (14.3.1+) - QR code generation
+- CoinbaseWalletSDK (1.1.0+) - Coinbase wallet integration
+- Yttrium (0.9.7) - External dependency for cryptographic operations
+
+### Installation
+The project supports installation via:
+- Swift Package Manager (SPM)
+- CocoaPods
+
+### Architecture
+The project follows a modular architecture with clear separation of concerns:
+- Networking layer handles all communication
+- Sign/Pairing modules manage the WalletConnect protocol
+- UI components are separated into their own modules
+- Each module has its own privacy manifest (PrivacyInfo.xcprivacy)
+
+## Project Structure
+```
+/Users/alexminator/conductor/repo/appkit/bandung/
+├── Sources/              # Main source code
+│   ├── ReownWalletKit/   # Main wallet SDK
+│   ├── ReownAppKit/      # App development kit
+│   ├── WalletConnect*/   # Various WalletConnect modules
+│   └── ...
+├── Tests/                # Unit and integration tests
+├── Example/              # Example applications
+│   ├── AppKitLab/        # AppKit demo app
+│   ├── DApp/             # Sample dApp
+│   └── WalletApp/        # Sample wallet app
+├── Package.swift         # SPM package definition
+├── reown-swift.podspec   # CocoaPods specification
+└── LICENSE               # Apache 2.0 license
+```
+
+## Version
+Current version: 1.6.5
+
+## License
+Apache License 2.0
+
+## Repository Information
+- GitHub: https://github.com/reown-com/reown-swift
+- Current branch: conductor/bandung
+- Main branch: develop
+
+## Notable Features
+- Full WalletConnect v2.0 protocol support
+- Coinbase Wallet SDK integration
+- Push notifications support
+- Identity and verification services
+- Comprehensive UI components
+- Event tracking and analytics
+- Support for multiple blockchain networks
+- Chain abstraction capabilities
+
+## Development Notes
+- The project uses git for version control
+- It includes comprehensive test coverage with unit and integration tests
+- CI/CD is configured with GitHub Actions
+- The project includes example apps for testing and demonstration
+- Uses CocoaPods and Swift Package Manager for dependency management

--- a/Sources/ReownAppKit/Core/AppKit.swift
+++ b/Sources/ReownAppKit/Core/AppKit.swift
@@ -19,6 +19,12 @@ import UIKit
 /// AppKit.instance.getSessions()
 /// ```
 public class AppKit {
+    /// Primary session topic for wallet connection
+    public static var primarySessionTopic: String? {
+        get { UserDefaults.standard.string(forKey: "appkit.primarySessionTopic") }
+        set { UserDefaults.standard.set(newValue, forKey: "appkit.primarySessionTopic") }
+    }
+    
     /// AppKit client instance
     public static var instance: AppKitClient = {
         guard let config = AppKit.config else {
@@ -34,7 +40,12 @@ public class AppKit {
         
         let store = Store.shared
         
-        if let session = client.getSessions().first {
+        // Try to find primary session first, then fall back to first session
+        let session = primarySessionTopic != nil 
+            ? client.getSessions().first(where: { $0.topic == primarySessionTopic })
+            : client.getSessions().first
+        
+        if let session = session {
             store.session = session
             store.connectedWith = .wc
             store.account = .init(from: session)

--- a/Sources/ReownAppKit/Core/AppKitClient.swift
+++ b/Sources/ReownAppKit/Core/AppKitClient.swift
@@ -267,9 +267,21 @@ public class AppKitClient {
     }
 
     /// Query sessions
-    /// - Returns: All sessions
+    /// - Returns: All sessions with primary session first
     public func getSessions() -> [Session] {
-        signClient.getSessions()
+        let allSessions = signClient.getSessions()
+        
+        // Sort sessions with primary session first
+        guard let primaryTopic = AppKit.primarySessionTopic else {
+            return allSessions
+        }
+        
+        return allSessions.sorted { lhs, rhs in
+            if lhs.topic == primaryTopic { return true }
+            if rhs.topic == primaryTopic { return false }
+            // Secondary sort by timestamp to maintain consistent order
+            return lhs.expiryDate < rhs.expiryDate
+        }
     }
     
     /// Query pairings

--- a/Sources/ReownAppKit/Sheets/Web3ModalViewModel.swift
+++ b/Sources/ReownAppKit/Sheets/Web3ModalViewModel.swift
@@ -153,6 +153,9 @@ class Web3ModalViewModel: ObservableObject {
         store.connectedWith = .wc
         store.account = .init(from: session)
         store.session = session
+        
+        // Set this session as the primary session
+        AppKit.primarySessionTopic = session.topic
 
         if
             let blockchain = session.accounts.first?.blockchain,

--- a/Sources/ReownAppKit/Store.swift
+++ b/Sources/ReownAppKit/Store.swift
@@ -38,6 +38,14 @@ class Store: ObservableObject {
     }
     
     // WalletConnect specific
+    var walletSession: Session? {
+        // Try to find primary session first, then fall back to first session
+        if let primaryTopic = AppKit.primarySessionTopic {
+            return AppKit.instance.getSessions().first(where: { $0.topic == primaryTopic })
+        }
+        return AppKit.instance.getSessions().first
+    }
+    
     @Published var session: Session? {
         didSet {
             if let blockchain = session?.accounts.first?.blockchain {


### PR DESCRIPTION
- Add primarySessionTopic property to AppKit for persistent primary session tracking
- Modify getSessions() to always return primary session first
- Add walletSession computed property to Store for consistent primary session access
- Set primary session topic when new wallet connection is established
- Ensure consistent session ordering across app restarts

This fixes the issue where dApp connections could appear before the main wallet connection in getSessions() results.
