### PR TITLE
Add possibility to update authRequestParams. 

### DIFF
--- a/Sources/ReownAppKit/Core/AppKit.swift
+++ b/Sources/ReownAppKit/Core/AppKit.swift
@@ -152,6 +152,10 @@ public class AppKit {
         AppKit.config.sessionParams = sessionParams
     }
     
+    public static func set(authRequestParams: AuthRequestParams) {
+        AppKit.config.authRequestParams = authRequestParams
+    }
+    
     private static func configureCoinbaseIfNeeded(
         store: Store,
         metadata: AppMetadata,


### PR DESCRIPTION
# Description

We should be able to update authRequestParams. At least nonce should be updatable.
We have case when nonce has only 2 minutes of live. And we should be able to update nonce

# Issue
This pr cover issue https://github.com/reown-com/reown-swift/issues/172

## How Has This Been Tested?
Our qa tested these functionality and it works well.
