### PR TITLE
Update QRCode package

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -3,11 +3,11 @@
     "pins": [
       {
         "package": "QRCode",
-        "repositoryURL": "https://github.com/WalletConnect/QRCode",
+        "repositoryURL": "https://github.com/dagronf/QRCode.git",
         "state": {
           "branch": null,
-          "revision": "263f280d2c8144adfb0b6676109846cfc8dd552b",
-          "version": "14.3.1"
+          "revision": "ea4047a7777bae470adc140cd94bfa5396a96202",
+          "version": "27.11.0"
         }
       },
       {
@@ -33,8 +33,8 @@
         "repositoryURL": "https://github.com/dagronf/swift-qrcode-generator",
         "state": {
           "branch": null,
-          "revision": "5ca09b6a2ad190f94aa3d6ddef45b187f8c0343b",
-          "version": "1.0.3"
+          "revision": "2b1980b825f08a81ccc762b0c4d17fcde9d5e953",
+          "version": "2.0.2"
         }
       },
       {
@@ -42,8 +42,8 @@
         "repositoryURL": "https://github.com/dagronf/SwiftImageReadWrite",
         "state": {
           "branch": null,
-          "revision": "5596407d1cf61b953b8e658fa8636a471df3c509",
-          "version": "1.1.6"
+          "revision": "42ace2412279f18bc264bc306e96b51c36e12a33",
+          "version": "1.9.2"
         }
       },
       {

--- a/Package.swift
+++ b/Package.swift
@@ -9,7 +9,7 @@ let yttriumDebug = false
 // Define dependencies array
 var dependencies: [Package.Dependency] = [
     .package(url: "https://github.com/apple/swift-docc-plugin", from: "1.3.0"),
-    .package(url: "https://github.com/WalletConnect/QRCode", from: "14.3.1"),
+    .package(url: "https://github.com/dagronf/QRCode.git", from: "27.11.0"),
     .package(name: "CoinbaseWalletSDK", url: "https://github.com/MobileWalletProtocol/wallet-mobile-sdk", .upToNextMinor(from: "1.1.0")),
 //    .package(url: "https://github.com/pointfreeco/swift-snapshot-testing", .upToNextMinor(from: "1.10.0")),
 ]

--- a/Sources/ReownAppKit/Screens/ConnectWallet/QRCodeView.swift
+++ b/Sources/ReownAppKit/Screens/ConnectWallet/QRCodeView.swift
@@ -25,10 +25,10 @@ struct QRCodeView: View {
     }
             
     @MainActor private func render(content: String, size: CGSize) -> Image {
-        let doc = QRCode.Document(
+        guard let doc = try? QRCode.Document(
             utf8String: content,
             errorCorrection: .quantize
-        )
+        ) else {return Image(systemName: "x.mark")}
         doc.design.shape.eye = QRCode.EyeShape.Squircle2()
         doc.design.shape.onPixels = QRCode.PixelShape.Vertical(
             insetFraction: 0.15,
@@ -62,11 +62,11 @@ struct QRCodeView: View {
                 inset: 20
             )
         }
-        return doc.imageUI(
+        return (try? doc.imageUI(
             size.applying(.init(scaleX: 3, y: 3)),
             dpi: 72 * 3,
             label: Text("QR code with URI")
-        )!
+        )) ?? Image(systemName: "x.mark")
     }
 }
 
@@ -115,6 +115,7 @@ struct QRCodeView_Previews: PreviewProvider {
 extension QRCode.EyeShape {
     /// A 'squircle' eye style
     @objc(QRCodeEyeShapeSquircle2) class Squircle2: NSObject, QRCodeEyeShapeGenerator {
+        
         @objc public static let Name = "squircle"
         @objc public static var Title: String { "Squircle2" }
         @objc public static func Create(_ settings: [String: Any]?) -> QRCodeEyeShapeGenerator {
@@ -149,6 +150,10 @@ extension QRCode.EyeShape {
 
         private static let _defaultPupil = QRCode.PupilShape.Squircle2()
         public func defaultPupil() -> QRCodePupilShapeGenerator { Self._defaultPupil }
+        
+        func reset() {
+            
+        }
     }
 }
 
@@ -182,6 +187,10 @@ extension QRCode.PupilShape {
             path.addRoundedRect(in: CGRect(x: offset, y: offset, width: size, height: size), cornerWidth: cornerRadius, cornerHeight: cornerRadius)
             
             return path
+        }
+        
+        func reset() {
+            
         }
     }
 }


### PR DESCRIPTION
Description

Updated QRCode package dependency from WalletConnect fork to the official dagronf/QRCode repository and upgraded to version 27.11.0. This change includes:

•  Switched QRCode package source from https://github.com/WalletConnect/QRCode to https://github.com/dagronf/QRCode.git
•  Upgraded QRCode from version 14.3.1 to 27.11.0
•  Updated related dependencies (swift-qrcode-generator from 1.0.3 to 2.0.2, SwiftImageReadWrite from 1.1.6 to 1.9.2)
•  Modified QRCodeView.swift to handle API changes with proper error handling using optional binding and fallback images
•  Added required reset() method implementations for custom QRCode shape extensions

This update provides access to the latest QRCode features and improvements while maintaining backward compatibility through error handling.

How Has This Been Tested?

Please test the following scenarios:
•  Verify QR code generation still works correctly in the ConnectWallet screen
•  Test QR code rendering with various content lengths and sizes
•  Ensure fallback behavior works when QR code generation fails (should show "x.mark" system icon)
•  Validate that the custom Squircle2 eye shape and pupil shapes still render correctly

To reproduce:
1. Navigate to the ConnectWallet screen
2. Verify QR code displays properly
3. Test with different wallet connection URIs

Due Diligence

No breaking change (API changes were handled with backward compatibility)