### PR TITLE
feat: add Canton blockchain integration to sample wallet

### DIFF
--- a/Example/ExampleApp.xcodeproj/project.pbxproj
+++ b/Example/ExampleApp.xcodeproj/project.pbxproj
@@ -36,6 +36,8 @@
 		44650A3F2E951D71004F2144 /* TonSigner.swift in Sources */ = {isa = PBXBuildFile; fileRef = 44650A3E2E951D71004F2144 /* TonSigner.swift */; };
 		44650A412F1E0001004F2144 /* TronAccountStorage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 44650A402F1E0001004F2144 /* TronAccountStorage.swift */; };
 		44650A432F1E0002004F2144 /* TronSigner.swift in Sources */ = {isa = PBXBuildFile; fileRef = 44650A422F1E0002004F2144 /* TronSigner.swift */; };
+		CA00CA012F3A0001000CA101 /* CantonAccountStorage.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA00CA022F3A0001000CA101 /* CantonAccountStorage.swift */; };
+		CA00CA032F3A0001000CA101 /* CantonSigner.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA00CA042F3A0001000CA101 /* CantonSigner.swift */; };
 		446A306B2DE8375E0024781A /* SolanaAccountStorage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 446A306A2DE8375E0024781A /* SolanaAccountStorage.swift */; };
 		446A306D2DE8405A0024781A /* SuiAccountStorage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 446A306C2DE8405A0024781A /* SuiAccountStorage.swift */; };
 		44713AA02E46420A00E3027A /* YttriumUtilsWrapper in Frameworks */ = {isa = PBXBuildFile; productRef = 44713A9F2E46420A00E3027A /* YttriumUtilsWrapper */; };
@@ -319,6 +321,8 @@
 		44650A3E2E951D71004F2144 /* TonSigner.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TonSigner.swift; sourceTree = "<group>"; };
 		44650A402F1E0001004F2144 /* TronAccountStorage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TronAccountStorage.swift; sourceTree = "<group>"; };
 		44650A422F1E0002004F2144 /* TronSigner.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TronSigner.swift; sourceTree = "<group>"; };
+		CA00CA022F3A0001000CA101 /* CantonAccountStorage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CantonAccountStorage.swift; sourceTree = "<group>"; };
+		CA00CA042F3A0001000CA101 /* CantonSigner.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CantonSigner.swift; sourceTree = "<group>"; };
 		446A306A2DE8375E0024781A /* SolanaAccountStorage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SolanaAccountStorage.swift; sourceTree = "<group>"; };
 		446A306C2DE8405A0024781A /* SuiAccountStorage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SuiAccountStorage.swift; sourceTree = "<group>"; };
 		44BA5CCC2E4C8BB50074A01E /* URLExtension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = URLExtension.swift; sourceTree = "<group>"; };
@@ -927,6 +931,7 @@
 				A57E71A7291CF8A500325797 /* SOLSigner.swift */,
 				44650A3E2E951D71004F2144 /* TonSigner.swift */,
 				44650A422F1E0002004F2144 /* TronSigner.swift */,
+				CA00CA042F3A0001000CA101 /* CantonSigner.swift */,
 			);
 			path = Signer;
 			sourceTree = "<group>";
@@ -1000,6 +1005,7 @@
 				446A306C2DE8405A0024781A /* SuiAccountStorage.swift */,
 				44650A3C2E93F775004F2144 /* TonAccountStorage.swift */,
 				44650A402F1E0001004F2144 /* TronAccountStorage.swift */,
+				CA00CA022F3A0001000CA101 /* CantonAccountStorage.swift */,
 				A5D610CC2AB3592F00C20083 /* ListingsSertice */,
 			);
 			path = BusinessLayer;
@@ -2002,6 +2008,7 @@
 				C55D34B22965FB750004314A /* SessionProposalView.swift in Sources */,
 				44650A3D2E93F775004F2144 /* TonAccountStorage.swift in Sources */,
 				44650A412F1E0001004F2144 /* TronAccountStorage.swift in Sources */,
+				CA00CA012F3A0001000CA101 /* CantonAccountStorage.swift in Sources */,
 				C56EE248293F566D004840D1 /* ScanQR.swift in Sources */,
 				C55D349B2965BC2F0004314A /* TagsView.swift in Sources */,
 				446A306B2DE8375E0024781A /* SolanaAccountStorage.swift in Sources */,
@@ -2031,6 +2038,7 @@
 				PAY0000012EE100000000000D /* PayDataCollectionWebView.swift in Sources */,
 				44650A3F2E951D71004F2144 /* TonSigner.swift in Sources */,
 				44650A432F1E0002004F2144 /* TronSigner.swift in Sources */,
+				CA00CA032F3A0001000CA101 /* CantonSigner.swift in Sources */,
 				C5B2F6F929705293000DBA0E /* SessionRequestPresenter.swift in Sources */,
 				44BA5CCD2E4C8BB50074A01E /* URLExtension.swift in Sources */,
 				A5D610CE2AB3594100C20083 /* ListingsAPI.swift in Sources */,

--- a/Example/Shared/Signer/CantonSigner.swift
+++ b/Example/Shared/Signer/CantonSigner.swift
@@ -1,0 +1,129 @@
+import Foundation
+import ReownWalletKit
+
+final class CantonSigner {
+    enum Errors: LocalizedError {
+        case unsupportedMethod(String)
+
+        var errorDescription: String? {
+            switch self {
+            case .unsupportedMethod(let method):
+                return "Unsupported Canton method: \(method)"
+            }
+        }
+    }
+
+    func sign(request: Request) async throws -> AnyCodable {
+        let networkId = request.chainId.absoluteString
+
+        switch request.method {
+        case "canton_listAccounts":
+            return listAccounts(networkId: networkId)
+        case "canton_getPrimaryAccount":
+            return getPrimaryAccount(networkId: networkId)
+        case "canton_getActiveNetwork":
+            return getActiveNetwork(networkId: networkId)
+        case "canton_status":
+            return getStatus(networkId: networkId)
+        case "canton_ledgerApi":
+            return ledgerApi(request: request)
+        case "canton_signMessage":
+            return signMessage()
+        case "canton_prepareSignExecute":
+            return prepareSignExecute(request: request)
+        default:
+            throw Errors.unsupportedMethod(request.method)
+        }
+    }
+
+    // MARK: - Mock Responses
+
+    private func accountObject(networkId: String) -> [String: Any] {
+        return [
+            "primary": true,
+            "partyId": CantonAccountStorage.partyId,
+            "status": "allocated",
+            "hint": "operator",
+            "publicKey": CantonAccountStorage.publicKeyBase64,
+            "namespace": CantonAccountStorage.cantonNamespace,
+            "networkId": networkId,
+            "signingProviderId": "participant",
+            "disabled": false
+        ]
+    }
+
+    private func listAccounts(networkId: String) -> AnyCodable {
+        return AnyCodable(any: [accountObject(networkId: networkId)])
+    }
+
+    private func getPrimaryAccount(networkId: String) -> AnyCodable {
+        return AnyCodable(any: accountObject(networkId: networkId))
+    }
+
+    private func getActiveNetwork(networkId: String) -> AnyCodable {
+        return AnyCodable(any: [
+            "networkId": networkId,
+            "ledgerApi": "http://127.0.0.1:5003"
+        ])
+    }
+
+    private func getStatus(networkId: String) -> AnyCodable {
+        return AnyCodable(any: [
+            "provider": [
+                "id": "remote-da",
+                "version": "3.4.0",
+                "providerType": "remote"
+            ],
+            "connection": [
+                "isConnected": true,
+                "isNetworkConnected": true
+            ],
+            "network": [
+                "networkId": networkId,
+                "ledgerApi": "http://127.0.0.1:5003"
+            ]
+        ] as [String: Any])
+    }
+
+    private func ledgerApi(request: Request) -> AnyCodable {
+        var resource = "/unknown"
+        if let params = try? request.params.get([String: AnyCodable].self),
+           let res = params["resource"]?.value as? String {
+            resource = res
+        }
+
+        if resource == "/v2/version" {
+            return AnyCodable(any: [
+                "response": "{\"version\":\"3.4.0\",\"features\":{}}"
+            ])
+        } else {
+            return AnyCodable(any: [
+                "response": "{\"mock\":true,\"resource\":\"\(resource)\"}"
+            ])
+        }
+    }
+
+    private func signMessage() -> AnyCodable {
+        return AnyCodable(any: [
+            "signature": CantonAccountStorage.publicKeyBase64,
+            "publicKey": CantonAccountStorage.publicKeyBase64
+        ])
+    }
+
+    private func prepareSignExecute(request: Request) -> AnyCodable {
+        var commandId = "mock-command-id-\(Int(Date().timeIntervalSince1970 * 1000))"
+        if let params = try? request.params.get([String: AnyCodable].self),
+           let id = params["commandId"]?.value as? String {
+            commandId = id
+        }
+
+        return AnyCodable(any: [
+            "status": "executed",
+            "commandId": commandId,
+            "payload": [
+                "updateId": "mock-tx-update-id",
+                "completionOffset": 42
+            ] as [String: Any]
+        ] as [String: Any])
+    }
+}

--- a/Example/Shared/Signer/Signer.swift
+++ b/Example/Shared/Signer/Signer.swift
@@ -79,6 +79,12 @@ final class Signer {
             throw Errors.accountForRequestNotFound
         }
 
+        // Handle Canton methods
+        if request.method.starts(with: "canton_") {
+            let cantonSigner = CantonSigner()
+            return try await cantonSigner.sign(request: request)
+        }
+
         // Default EOA route
         let requestedAddress = try await getRequestedAddress(request)
 
@@ -115,6 +121,11 @@ final class Signer {
                 return suiAddress
             }
             throw Errors.cantFindRequestedAddress
+        }
+
+        // Canton methods: return hardcoded address
+        if request.method.starts(with: "canton_") {
+            return CantonAccountStorage.partyIdUrlEncoded
         }
 
         // Stacks methods: read from StacksAccountStorage for specific chain

--- a/Example/WalletApp/BusinessLayer/CantonAccountStorage.swift
+++ b/Example/WalletApp/BusinessLayer/CantonAccountStorage.swift
@@ -1,0 +1,21 @@
+import Foundation
+import ReownWalletKit
+
+struct CantonAccountStorage {
+    static let partyId = "operator::1220abcdef1234567890abcdef1234567890abcdef1234567890abcdef12345678"
+    static let partyIdUrlEncoded = "operator%3A%3A1220abcdef1234567890abcdef1234567890abcdef1234567890abcdef12345678"
+    static let publicKeyBase64 = "q83vEjRWeJCrze8SNFZbkKvN7xI0VluQq83vEjRWeJg="
+    static let cantonNamespace = "1220abcdef1234567890abcdef1234567890abcdef1234567890abcdef12345678"
+
+    static let mainnetChainId: Blockchain = Blockchain("canton:mainnet")!
+    static let devnetChainId: Blockchain = Blockchain("canton:devnet")!
+
+    func getAddress(for chainId: Blockchain? = nil) -> String {
+        return Self.partyIdUrlEncoded
+    }
+
+    func getCaip10Account(for chainId: Blockchain? = nil) -> Account? {
+        let resolvedChainId = chainId ?? Self.mainnetChainId
+        return Account(blockchain: resolvedChainId, address: Self.partyIdUrlEncoded)
+    }
+}

--- a/Example/WalletApp/Common/Views/ChainIconProvider.swift
+++ b/Example/WalletApp/Common/Views/ChainIconProvider.swift
@@ -57,6 +57,12 @@ enum ChainIconProvider {
             case "0xcd8690dc": return ("Tron", "Tron Testnet")
             default: return ("Tron", "Tron")
             }
+        case "canton":
+            switch ref {
+            case "mainnet": return ("Canton", "Canton")
+            case "devnet": return ("Canton", "Canton Devnet")
+            default: return ("Canton", "Canton")
+            }
         default: return nil
         }
     }

--- a/Example/WalletApp/PresentationLayer/Wallet/SessionProposal/SessionProposalInteractor.swift
+++ b/Example/WalletApp/PresentationLayer/Wallet/SessionProposal/SessionProposalInteractor.swift
@@ -14,6 +14,7 @@ final class SessionProposalInteractor {
         let suiAccountStorage = SuiAccountStorage()
         let tonAccountStorage = TonAccountStorage()
         let tronAccountStorage = TronAccountStorage()
+        let cantonAccountStorage = CantonAccountStorage()
         let solanaAccountStorage = SolanaAccountStorage()
 
         // Filter chains by user selection when provided
@@ -52,8 +53,13 @@ final class SessionProposalInteractor {
         let supportedOptionalTronChains = proposal.optionalNamespaces?["tron"]?.chains ?? []
         let supportedTronChains = filterSelected(supportedRequiredTronChains + supportedOptionalTronChains)
 
+        // Handle Canton chains
+        let supportedRequiredCantonChains = proposal.requiredNamespaces["canton"]?.chains ?? []
+        let supportedOptionalCantonChains = proposal.optionalNamespaces?["canton"]?.chains ?? []
+        let supportedCantonChains = filterSelected(supportedRequiredCantonChains + supportedOptionalCantonChains)
+
         // Combine supported chains; add optional groups only when available
-        var supportedChains = supportedEIP155Chains + supportedStacksChains + supportedSuiChains + supportedTonChains + supportedTronChains
+        var supportedChains = supportedEIP155Chains + supportedStacksChains + supportedSuiChains + supportedTonChains + supportedTronChains + supportedCantonChains
 
         var supportedAccounts: [Account] = []
         var sessionProperties = [String: String]()
@@ -117,6 +123,17 @@ final class SessionProposalInteractor {
             supportedAccounts.append(contentsOf: tronAccounts)
             // Add Tron session property for v1 transaction format
             sessionProperties["tron_method_version"] = "v1"
+        }
+
+        // Add Canton accounts if available
+        if !supportedCantonChains.isEmpty {
+            var cantonAccounts: [Account] = []
+            for chain in supportedCantonChains {
+                if let cantonAccount = cantonAccountStorage.getCaip10Account(for: chain) {
+                    cantonAccounts.append(cantonAccount)
+                }
+            }
+            supportedAccounts.append(contentsOf: cantonAccounts)
         }
 
         /* Use only supported values for production. I.e:

--- a/Example/WalletApp/PresentationLayer/Wallet/SessionProposal/SessionProposalPresenter.swift
+++ b/Example/WalletApp/PresentationLayer/Wallet/SessionProposal/SessionProposalPresenter.swift
@@ -199,6 +199,8 @@ final class SessionProposalPresenter: ObservableObject {
             )
         } else if chain.namespace.caseInsensitiveCompare("solana") == .orderedSame {
             signature = try solanaSignature(for: message)
+        } else if chain.namespace.caseInsensitiveCompare("canton") == .orderedSame {
+            signature = CacaoSignature(t: .ed25519, s: CantonAccountStorage.publicKeyBase64)
         } else {
             throw Errors.noCommonChains
         }
@@ -263,6 +265,11 @@ private extension SessionProposalPresenter {
             return Account(blockchain: chain, address: solanaAccount.address)
         }
 
+        if chain.namespace.caseInsensitiveCompare("canton") == .orderedSame {
+            let cantonAccountStorage = CantonAccountStorage()
+            return cantonAccountStorage.getCaip10Account(for: chain)
+        }
+
         return nil
     }
 
@@ -276,6 +283,11 @@ private extension SessionProposalPresenter {
             }
             supported.formUnion(solanaChains)
         }
+
+        let cantonChains = requestedChains.filter { chain in
+            chain.namespace.caseInsensitiveCompare("canton") == .orderedSame
+        }
+        supported.formUnion(cantonChains)
 
         return supported
     }


### PR DESCRIPTION
## Summary
- Add Canton namespace (`canton:mainnet`, `canton:devnet`) to the sample wallet so it can connect to dApps via WalletConnect and respond to Canton RPC methods with mocked responses
- All 7 Canton methods return hardcoded mock data: `canton_listAccounts`, `canton_getPrimaryAccount`, `canton_getActiveNetwork`, `canton_status`, `canton_ledgerApi`, `canton_signMessage`, `canton_prepareSignExecute`
- Hardcoded party ID (`operator::1220...`) with URL-encoded CAIP-10 accounts per the Canton spec

```mermaid
flowchart LR
    subgraph react-dapp
        A[Canton RPC request]
    end
    subgraph swift-wallet
        B[WalletKit delegate] --> C[SessionRequestPresenter]
        C --> D[Signer.sign]
        D --> E[CantonSigner — mock responses]
    end
    A -->|WalletConnect| B
    E -->|JSON-RPC result| A
```

### Files changed
| File | Change |
|------|--------|
| `CantonAccountStorage.swift` | **New** — hardcoded Canton account constants |
| `CantonSigner.swift` | **New** — mock response handlers for all 7 Canton methods |
| `Signer.swift` | Added `canton_` method prefix routing to CantonSigner |
| `SessionProposalInteractor.swift` | Added Canton namespace handling for session approval |
| `SessionProposalPresenter.swift` | Added Canton auth chain resolution |
| `ChainIconProvider.swift` | Added Canton mainnet/devnet display names |
| `project.pbxproj` | Registered new files in WalletApp target |

### Context
- Mirrors Kotlin implementation: reown-com/reown-kotlin#361
- Canton spec: WalletConnectFoundation/docs#139
- Web examples reference: reown-com/web-examples#1017

## Test plan
- [x] Build: `xcodebuild -scheme WalletApp` passes
- [ ] Connect Swift wallet to react-dapp-v2 with Canton chains selected
- [ ] Session proposal shows Canton chains
- [ ] Approve session — Canton namespace included
- [ ] Send each Canton RPC method from dapp → wallet shows approval dialog → approve → mock response returned

🤖 Generated with [Claude Code](https://claude.com/claude-code)