### PR TITLE
feat: add maestro tests to Pay flow in sample wallet

### DIFF
--- a/.env.maestro.example
+++ b/.env.maestro.example
@@ -1,0 +1,10 @@
+# Maestro Pay E2E test credentials
+# Copy this file to .env.maestro and fill in the values.
+# These are WalletConnect Pay merchant API keys for different test scenarios.
+
+WPAY_CUSTOMER_KEY_SINGLE_NOKYC=
+WPAY_MERCHANT_ID_SINGLE_NOKYC=
+WPAY_CUSTOMER_KEY_MULTI_NOKYC=
+WPAY_MERCHANT_ID_MULTI_NOKYC=
+WPAY_CUSTOMER_KEY_MULTI_KYC=
+WPAY_MERCHANT_ID_MULTI_KYC=

--- a/.github/workflows/ci_e2e_pay_tests.yml
+++ b/.github/workflows/ci_e2e_pay_tests.yml
@@ -5,17 +5,10 @@ on:
     branches:
       - develop
       - main
-  workflow_dispatch:
-    inputs:
-      maestro_flows_ref:
-        description: 'Branch/tag of WalletConnect/actions for test flows'
-        required: false
-        default: 'main'
+  workflow_dispatch: {}
 
 permissions:
   contents: read
-  checks: write
-  actions: read
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref_name }}
@@ -30,6 +23,9 @@ jobs:
     needs: check-balance
     runs-on: macos-latest-xlarge
     timeout-minutes: 45
+    permissions:
+      checks: write
+      actions: read
     steps:
       - uses: actions/checkout@v3
 

--- a/.github/workflows/ci_e2e_pay_tests.yml
+++ b/.github/workflows/ci_e2e_pay_tests.yml
@@ -22,7 +22,12 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  check-balance:
+    uses: ./.github/workflows/e2e_balance_check.yml
+    secrets: inherit
+
   e2e-pay-tests:
+    needs: check-balance
     runs-on: macos-latest-xlarge
     timeout-minutes: 45
     steps:

--- a/.github/workflows/ci_e2e_pay_tests.yml
+++ b/.github/workflows/ci_e2e_pay_tests.yml
@@ -62,7 +62,7 @@ jobs:
       - name: Install Maestro
         uses: WalletConnect/actions/maestro/setup@f9522878950f7bd904a628b2c4d486b93034a4fe # main
         with:
-          version: '1.39.15'
+          version: '2.4.0'
 
       - name: Boot iOS simulator
         run: |

--- a/.github/workflows/ci_e2e_pay_tests.yml
+++ b/.github/workflows/ci_e2e_pay_tests.yml
@@ -1,0 +1,107 @@
+name: Maestro E2E Pay Tests
+
+on:
+  pull_request:
+    branches:
+      - develop
+      - main
+  workflow_dispatch:
+    inputs:
+      maestro_flows_ref:
+        description: 'Branch/tag of WalletConnect/actions for test flows'
+        required: false
+        default: 'master'
+
+permissions:
+  contents: read
+  checks: write
+  actions: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref_name }}
+  cancel-in-progress: true
+
+jobs:
+  e2e-pay-tests:
+    runs-on: macos-latest-xlarge
+    timeout-minutes: 45
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Select Xcode 26 (iOS 26 SDK)
+        uses: maxim-lobanov/setup-xcode@v1
+        with:
+          xcode-version: '26'
+
+      - uses: actions/cache@v3
+        with:
+          path: |
+            **/SourcePackagesCache
+          key: ${{ runner.os }}-spm-${{ hashFiles('**/Package.resolved') }}
+
+      - name: Build WalletApp for simulator (test mode)
+        run: |
+          set -o pipefail && env NSUnbufferedIO=YES \
+            xcodebuild \
+            -project "Example/ExampleApp.xcodeproj" \
+            -scheme "WalletApp" \
+            -destination "platform=iOS Simulator,name=iPhone 16" \
+            -derivedDataPath DerivedDataCache \
+            -clonedSourcePackagesDirPath ../SourcePackagesCache \
+            RELAY_HOST='relay.walletconnect.com' \
+            PROJECT_ID='${{ secrets.PROJECT_ID }}' \
+            TEST_WALLET_PRIVATE_KEY='${{ secrets.TEST_WALLET_PRIVATE_KEY }}' \
+            SWIFT_ACTIVE_COMPILATION_CONDITIONS='$(inherited) ENABLE_TEST_MODE' \
+            build \
+            | xcbeautify
+
+      - name: Copy shared Pay test flows
+        uses: WalletConnect/actions/maestro/pay-tests@master
+
+      - name: Install Maestro
+        uses: WalletConnect/actions/maestro/setup@master
+
+      - name: Boot iOS simulator
+        run: |
+          xcrun simctl boot "iPhone 16" 2>/dev/null || true
+          xcrun simctl bootstatus "iPhone 16"
+
+      - name: Install app on simulator
+        run: |
+          APP_PATH=$(find DerivedDataCache -name "WalletApp.app" -path "*/Debug-iphonesimulator/*" | head -1)
+          if [ -z "$APP_PATH" ]; then
+            echo "ERROR: WalletApp.app not found in DerivedDataCache"
+            find DerivedDataCache -name "*.app" -path "*/Debug-iphonesimulator/*"
+            exit 1
+          fi
+          echo "Installing: $APP_PATH"
+          xcrun simctl install booted "$APP_PATH"
+
+      - name: Run Maestro Pay E2E tests
+        run: |
+          maestro test \
+            --env APP_ID=com.walletconnect.walletapp \
+            --env WPAY_CUSTOMER_KEY_SINGLE_NOKYC=${{ secrets.WPAY_CUSTOMER_KEY_SINGLE_NOKYC }} \
+            --env WPAY_MERCHANT_ID_SINGLE_NOKYC=${{ secrets.WPAY_MERCHANT_ID_SINGLE_NOKYC }} \
+            --env WPAY_CUSTOMER_KEY_MULTI_NOKYC=${{ secrets.WPAY_CUSTOMER_KEY_MULTI_NOKYC }} \
+            --env WPAY_MERCHANT_ID_MULTI_NOKYC=${{ secrets.WPAY_MERCHANT_ID_MULTI_NOKYC }} \
+            --env WPAY_CUSTOMER_KEY_MULTI_KYC=${{ secrets.WPAY_CUSTOMER_KEY_MULTI_KYC }} \
+            --env WPAY_MERCHANT_ID_MULTI_KYC=${{ secrets.WPAY_MERCHANT_ID_MULTI_KYC }} \
+            --include-tags pay \
+            --test-output-dir debug-artifacts/maestro-output \
+            --debug-output debug-artifacts/maestro-debug \
+            .maestro/
+
+      - name: Capture simulator logs
+        if: always()
+        run: |
+          xcrun simctl spawn booted log collect --output debug-artifacts/sim-logs.logarchive 2>/dev/null || true
+
+      - name: Upload debug artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: maestro-pay-test-artifacts
+          path: debug-artifacts/
+          retention-days: 14
+          if-no-files-found: ignore

--- a/.github/workflows/ci_e2e_pay_tests.yml
+++ b/.github/workflows/ci_e2e_pay_tests.yml
@@ -10,7 +10,7 @@ on:
       maestro_flows_ref:
         description: 'Branch/tag of WalletConnect/actions for test flows'
         required: false
-        default: 'master'
+        default: 'feat/maestro-pay-actions'
 
 permissions:
   contents: read
@@ -56,10 +56,10 @@ jobs:
             | xcbeautify
 
       - name: Copy shared Pay test flows
-        uses: WalletConnect/actions/maestro/pay-tests@master
+        uses: WalletConnect/actions/maestro/pay-tests@feat/maestro-pay-actions
 
       - name: Install Maestro
-        uses: WalletConnect/actions/maestro/setup@master
+        uses: WalletConnect/actions/maestro/setup@feat/maestro-pay-actions
 
       - name: Boot iOS simulator
         run: |

--- a/.github/workflows/ci_e2e_pay_tests.yml
+++ b/.github/workflows/ci_e2e_pay_tests.yml
@@ -61,6 +61,8 @@ jobs:
 
       - name: Install Maestro
         uses: WalletConnect/actions/maestro/setup@f9522878950f7bd904a628b2c4d486b93034a4fe # main
+        with:
+          version: '1.39.15'
 
       - name: Boot iOS simulator
         run: |

--- a/.github/workflows/ci_e2e_pay_tests.yml
+++ b/.github/workflows/ci_e2e_pay_tests.yml
@@ -10,7 +10,7 @@ on:
       maestro_flows_ref:
         description: 'Branch/tag of WalletConnect/actions for test flows'
         required: false
-        default: 'feat/maestro-pay-actions'
+        default: 'main'
 
 permissions:
   contents: read
@@ -57,10 +57,10 @@ jobs:
             | xcbeautify
 
       - name: Copy shared Pay test flows
-        uses: WalletConnect/actions/maestro/pay-tests@feat/maestro-pay-actions
+        uses: WalletConnect/actions/maestro/pay-tests@f9522878950f7bd904a628b2c4d486b93034a4fe # main
 
       - name: Install Maestro
-        uses: WalletConnect/actions/maestro/setup@feat/maestro-pay-actions
+        uses: WalletConnect/actions/maestro/setup@f9522878950f7bd904a628b2c4d486b93034a4fe # main
 
       - name: Boot iOS simulator
         run: |

--- a/.github/workflows/ci_e2e_pay_tests.yml
+++ b/.github/workflows/ci_e2e_pay_tests.yml
@@ -40,6 +40,7 @@ jobs:
           key: ${{ runner.os }}-spm-${{ hashFiles('**/Package.resolved') }}
 
       - name: Build WalletApp for simulator (test mode)
+        id: build
         run: |
           set -o pipefail && env NSUnbufferedIO=YES \
             xcodebuild \
@@ -78,6 +79,7 @@ jobs:
           xcrun simctl install booted "$APP_PATH"
 
       - name: Run Maestro Pay E2E tests
+        id: maestro
         run: |
           maestro test \
             --env APP_ID=com.walletconnect.walletapp \
@@ -105,3 +107,52 @@ jobs:
           path: debug-artifacts/
           retention-days: 14
           if-no-files-found: ignore
+
+      - name: Send Slack notification
+        if: failure()
+        uses: slackapi/slack-github-action@b0fa283ad8fea605de13dc3f449259339835fc52 # v2.1.0
+        with:
+          webhook: ${{ secrets.SLACK_WEBHOOK_URL }}
+          webhook-type: incoming-webhook
+          payload: |
+            {
+              "text": "E2E Test Report - iOS - Pay",
+              "blocks": [
+                {
+                  "type": "header",
+                  "text": { "type": "plain_text", "text": "🧪 E2E Test Report - iOS (pay)" }
+                },
+                {
+                  "type": "section",
+                  "fields": [
+                    { "type": "mrkdwn", "text": "*Project:*\n`Reown Swift`" },
+                    { "type": "mrkdwn", "text": "*Platform:*\n`iOS`" },
+                    { "type": "mrkdwn", "text": "*Branch:*\n`${{ github.ref_name }}`" },
+                    { "type": "mrkdwn", "text": "*Trigger:*\n`${{ github.event_name }}`" }
+                  ]
+                },
+                {
+                  "type": "section",
+                  "fields": [
+                    { "type": "mrkdwn", "text": "*Build:*\n`${{ steps.build.outcome == 'success' && '✅ Success' || '❌ Failed' }}`" },
+                    { "type": "mrkdwn", "text": "*Maestro Tests:*\n`${{ steps.maestro.outcome == 'success' && '✅ Passed' || '❌ Failed' }}`" },
+                    { "type": "mrkdwn", "text": "*Overall Status:*\n`${{ job.status == 'success' && '✅ Success' || '❌ Failed' }}`" }
+                  ]
+                },
+                {
+                  "type": "actions",
+                  "elements": [
+                    {
+                      "type": "button",
+                      "text": { "type": "plain_text", "text": "View Workflow Run" },
+                      "url": "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+                    },
+                    {
+                      "type": "button",
+                      "text": { "type": "plain_text", "text": "Download Artifacts" },
+                      "url": "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}#artifacts"
+                    }
+                  ]
+                }
+              ]
+            }

--- a/.github/workflows/ci_e2e_pay_tests.yml
+++ b/.github/workflows/ci_e2e_pay_tests.yml
@@ -21,6 +21,7 @@ jobs:
 
   e2e-pay-tests:
     needs: check-balance
+    if: always() # Balance alert should not block tests
     runs-on: macos-latest-xlarge
     timeout-minutes: 45
     permissions:

--- a/.github/workflows/e2e_balance_check.yml
+++ b/.github/workflows/e2e_balance_check.yml
@@ -1,9 +1,8 @@
 name: E2E Wallet Balance Check
 
 on:
-  schedule:
-    - cron: '0 * * * *' # Every hour
   workflow_dispatch: {}
+  workflow_call: {}
 
 permissions:
   contents: read

--- a/.github/workflows/e2e_balance_check.yml
+++ b/.github/workflows/e2e_balance_check.yml
@@ -1,0 +1,115 @@
+name: E2E Wallet Balance Check
+
+on:
+  schedule:
+    - cron: '0 * * * *' # Every hour
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
+
+env:
+  BASE_USDC: '0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913'
+  BASE_RPC: 'https://mainnet.base.org'
+  OP_USDC: '0x0b2C639c533813f4Aa9D7837CAf62653d097Ff85'
+  OP_RPC: 'https://mainnet.optimism.io'
+
+jobs:
+  check-balance:
+    name: Check E2E Wallet Balances
+    runs-on: ubuntu-latest
+    env:
+      SLACK_FAUCETBOT_WEBHOOK_URL: ${{ secrets.SLACK_FAUCETBOT_WEBHOOK_URL }}
+    steps:
+      - name: Install Foundry
+        uses: foundry-rs/foundry-toolchain@8789b3e21e6c11b2697f5eb56eddae542f746c10 # v1
+
+      - name: Check USDC balance on Base
+        id: usdc_balance
+        run: |
+          BALANCE=$(cast call --rpc-url "$BASE_RPC" "$BASE_USDC" \
+            "balanceOf(address)(uint256)" \
+            "${{ vars.TEST_WALLET_ADDRESS }}" | sed 's/\[.*\]//' | tr -d '[:space:]')
+          echo "balance=$BALANCE" >> $GITHUB_OUTPUT
+          BALANCE_HUMAN=$(echo "scale=2; $BALANCE / 1000000" | bc)
+          echo "USDC on Base: $BALANCE_HUMAN ($BALANCE raw)"
+
+      - name: Prepare USDC alert
+        id: usdc_alert
+        run: |
+          BALANCE="${{ steps.usdc_balance.outputs.balance }}"
+          THRESHOLD="${{ vars.USDC_THRESHOLD_UNITS || '1000000' }}"
+          if [ "$BALANCE" -lt "$THRESHOLD" ]; then
+            BALANCE_HUMAN=$(echo "scale=2; $BALANCE / 1000000" | bc)
+            THRESHOLD_HUMAN=$(echo "scale=2; $THRESHOLD / 1000000" | bc)
+            ALERT_TEXT="[request] Can i have ${THRESHOLD_HUMAN} USDC on Base in wallet: \
+              ${{ vars.TEST_WALLET_ADDRESS }}"
+            echo "should_alert=true" >> "$GITHUB_OUTPUT"
+            echo "text=$ALERT_TEXT" >> "$GITHUB_OUTPUT"
+            echo "::warning::$ALERT_TEXT"
+          fi
+
+      - name: Send Slack alert (USDC)
+        if: |
+          steps.usdc_alert.outputs.should_alert == 'true' &&
+          env.SLACK_FAUCETBOT_WEBHOOK_URL != ''
+        uses: slackapi/slack-github-action@b0fa283ad8fea605de13dc3f449259339835fc52 # v2.1.0
+        with:
+          webhook: ${{ env.SLACK_FAUCETBOT_WEBHOOK_URL }}
+          webhook-type: incoming-webhook
+          payload: |
+            {
+              "text": "${{ steps.usdc_alert.outputs.text }}"
+            }
+
+      - name: Skip Slack alert (USDC - no webhook)
+        if: |
+          steps.usdc_alert.outputs.should_alert == 'true' &&
+          env.SLACK_FAUCETBOT_WEBHOOK_URL == ''
+        run: |
+          echo "::warning::SLACK_FAUCETBOT_WEBHOOK_URL not configured, skipping USDC alert"
+
+      - name: Check USDC balance on Optimism
+        id: op_usdc_balance
+        run: |
+          BALANCE=$(cast call --rpc-url "$OP_RPC" "$OP_USDC" \
+            "balanceOf(address)(uint256)" \
+            "${{ vars.TEST_WALLET_ADDRESS }}" | sed 's/\[.*\]//' | tr -d '[:space:]')
+          echo "balance=$BALANCE" >> $GITHUB_OUTPUT
+          BALANCE_HUMAN=$(echo "scale=2; $BALANCE / 1000000" | bc)
+          echo "USDC on Optimism: $BALANCE_HUMAN ($BALANCE raw)"
+
+      - name: Prepare USDC on Optimism alert
+        id: op_usdc_alert
+        run: |
+          BALANCE="${{ steps.op_usdc_balance.outputs.balance }}"
+          THRESHOLD="${{ vars.USDC_THRESHOLD_UNITS || '1000000' }}"
+          if [ "$BALANCE" -lt "$THRESHOLD" ]; then
+            BALANCE_HUMAN=$(echo "scale=2; $BALANCE / 1000000" | bc)
+            THRESHOLD_HUMAN=$(echo "scale=2; $THRESHOLD / 1000000" | bc)
+            ALERT_TEXT="[request] Can i have ${THRESHOLD_HUMAN} USDC on Optimism in wallet: \
+              ${{ vars.TEST_WALLET_ADDRESS }}"
+            echo "should_alert=true" >> "$GITHUB_OUTPUT"
+            echo "text=$ALERT_TEXT" >> "$GITHUB_OUTPUT"
+            echo "::warning::$ALERT_TEXT"
+          fi
+
+      - name: Send Slack alert (USDC on Optimism)
+        if: |
+          steps.op_usdc_alert.outputs.should_alert == 'true' &&
+          env.SLACK_FAUCETBOT_WEBHOOK_URL != ''
+        uses: slackapi/slack-github-action@b0fa283ad8fea605de13dc3f449259339835fc52 # v2.1.0
+        with:
+          webhook: ${{ env.SLACK_FAUCETBOT_WEBHOOK_URL }}
+          webhook-type: incoming-webhook
+          payload: |
+            {
+              "text": "${{ steps.op_usdc_alert.outputs.text }}"
+            }
+
+      - name: Skip Slack alert (USDC on Optimism - no webhook)
+        if: |
+          steps.op_usdc_alert.outputs.should_alert == 'true' &&
+          env.SLACK_FAUCETBOT_WEBHOOK_URL == ''
+        run: |
+          echo "::warning::SLACK_FAUCETBOT_WEBHOOK_URL not configured, skipping Optimism USDC alert"

--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,10 @@ fastlane/screenshots/**/*.png
 fastlane/test_output
 fastlane/README.md
 .env
+.env.maestro
+
+# Maestro E2E test flows (downloaded at runtime)
+.maestro/
 
 # Configuration - local overrides (Configuration.xcconfig is tracked as template)
 Configuration.local.xcconfig

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,3 +22,53 @@ xcodebuild -scheme <scheme_name>
 ## Project Structure
 
 This is the Reown Swift SDK repository containing iOS/macOS SDKs for WalletConnect services.
+
+## Maestro E2E Pay Tests
+
+The wallet sample app includes Maestro E2E tests for WalletConnect Pay flows. The shared test flows are downloaded from `WalletConnect/actions` repo at runtime.
+
+### Prerequisites
+
+- [Maestro CLI](https://maestro.mobile.dev) installed
+- iOS simulator booted
+- Merchant API credentials in `.env.maestro` (copy from `.env.maestro.example`)
+
+### Setup & Run
+
+```bash
+# 1. Download shared test flows
+./scripts/setup-maestro-pay-tests.sh
+
+# 2. Build with test mode enabled (optionally with a pre-funded wallet)
+xcodebuild \
+  -project "Example/ExampleApp.xcodeproj" \
+  -scheme "WalletApp" \
+  -destination "platform=iOS Simulator,name=iPhone 16" \
+  -derivedDataPath DerivedDataCache \
+  RELAY_HOST='relay.walletconnect.com' \
+  PROJECT_ID='<your-project-id>' \
+  TEST_WALLET_PRIVATE_KEY='<your-funded-wallet-private-key>' \
+  SWIFT_ACTIVE_COMPILATION_CONDITIONS='$(inherited) ENABLE_TEST_MODE' \
+  build
+
+# 3. Install on simulator
+xcrun simctl boot "iPhone 16" 2>/dev/null || true
+xcrun simctl install booted "$(find DerivedDataCache -name 'WalletApp.app' -path '*/Debug-iphonesimulator/*' | head -1)"
+
+# 4. Run tests
+./scripts/run-maestro-pay-tests.sh
+```
+
+### Test Mode
+
+The `ENABLE_TEST_MODE` Swift compilation flag enables two features:
+- **URL text input**: Adds a visible text field to the scanner options sheet, allowing Maestro to type payment URLs directly instead of scanning QR codes.
+- **Test wallet import**: If `TEST_WALLET_PRIVATE_KEY` is provided as a build setting, the app imports that EVM private key on launch instead of generating a random wallet. This allows CI to use a pre-funded wallet for Pay tests.
+
+Both are passed via xcodebuild build settings — no Xcode project changes needed.
+
+### Accessibility Identifiers
+
+All Pay UI views have accessibility identifiers matching the shared Maestro test flows (e.g., `pay-button-pay`, `pay-option-0-selected`, `pay-result-success-icon`). These IDs must stay in sync with `WalletConnect/actions/maestro/pay-tests`.
+
+Important: for custom SwiftUI `Shape`/wrapper content, putting `.accessibilityIdentifier(...)` on an arbitrary SwiftUI container is not always enough for Maestro/XCUITest on iOS. The Pay result icons and KYC badge had to be exposed on underlying native accessible elements (`UIImageView` / `UILabel`) before Maestro could reliably find them. If a visible element is failing by `id`, verify the identifier is attached to the actual native accessibility element, not just a SwiftUI wrapper.

--- a/Example/Shared/InputConfig.swift
+++ b/Example/Shared/InputConfig.swift
@@ -25,6 +25,10 @@ struct InputConfig {
         return config(for: "PAY_API_KEY")
     }
 
+    static var testWalletPrivateKey: String? {
+        return config(for: "TEST_WALLET_PRIVATE_KEY")
+    }
+
     private static func config(for key: String) -> String? {
         return Bundle.main.object(forInfoDictionaryKey: key) as? String
     }

--- a/Example/WalletApp/ApplicationLayer/Configurator/ApplicationConfigurator.swift
+++ b/Example/WalletApp/ApplicationLayer/Configurator/ApplicationConfigurator.swift
@@ -12,12 +12,27 @@ struct ApplicationConfigurator: Configurator {
 
     func configure() {
         let importAccount: ImportAccount
+        let service = WalletGenerationService(accountStorage: app.accountStorage)
+
+        #if ENABLE_TEST_MODE
+        // In test mode, use a pre-funded wallet if a private key is provided
+        if let testKey = InputConfig.testWalletPrivateKey, !testKey.isEmpty,
+           service.importEVMPrivateKey(testKey),
+           let account = app.accountStorage.importAccount {
+            importAccount = account
+            print("🧪 [TestMode] Imported test wallet: \(account.account.address)")
+        } else if let existing = app.accountStorage.importAccount {
+            importAccount = existing
+        } else {
+            importAccount = service.generateAllWallets()
+        }
+        #else
         if let existing = app.accountStorage.importAccount {
             importAccount = existing
         } else {
-            let service = WalletGenerationService(accountStorage: app.accountStorage)
             importAccount = service.generateAllWallets()
         }
+        #endif
 
         precondition(Thread.isMainThread, "ApplicationConfigurator.configure() must be called on the main thread")
         MainActor.assumeIsolated {

--- a/Example/WalletApp/ApplicationLayer/SceneDelegate.swift
+++ b/Example/WalletApp/ApplicationLayer/SceneDelegate.swift
@@ -19,16 +19,19 @@ final class SceneDelegate: UIResponder, UIWindowSceneDelegate {
     }
 
     func scene(_ scene: UIScene, continue userActivity: NSUserActivity) {
-        guard let url = userActivity.webpageURL,
-              let components = URLComponents(url: url, resolvingAgainstBaseURL: true) else {
+        guard let url = userActivity.webpageURL else {
             return
         }
-        
+
+        if handleIncomingURL(url) {
+            return
+        }
+
         // Extract topic from URL
         if let topic = extractTopicFromURL(url.absoluteString) {
             LinkModeTopicsStorage.shared.addTopic(topic)
         }
-        
+
         do {
             try WalletKit.instance.dispatchEnvelope(url.absoluteString)
         } catch {
@@ -58,15 +61,19 @@ final class SceneDelegate: UIResponder, UIWindowSceneDelegate {
             let url = urlContext.url
             print("🔗 [PayDeeplink] Cold start - Received URL: \(url.absoluteString)")
             pendingPaymentLink = extractPaymentLink(from: url)
+        } else if let userActivityURL = connectionOptions.userActivities.first?.webpageURL {
+            print("🔗 [PayDeeplink] Cold start - Received universal link: \(userActivityURL.absoluteString)")
+            pendingPaymentLink = extractPaymentLink(from: userActivityURL)
         } else {
-            print("🔗 [PayDeeplink] Cold start - No URL context")
+            print("🔗 [PayDeeplink] Cold start - No URL context or user activity")
         }
 
         // Process connection options (only if not a pay-only deeplink)
         // If `pay` param exists but no `uri`, skip pairing
         let hasPayParam = pendingPaymentLink != nil
-        let hasUriParam = connectionOptions.urlContexts.first.flatMap { context -> Bool in
-            guard let components = URLComponents(url: context.url, resolvingAgainstBaseURL: false),
+        let incomingURL = connectionOptions.urlContexts.first?.url ?? connectionOptions.userActivities.first?.webpageURL
+        let hasUriParam = incomingURL.flatMap { url -> Bool in
+            guard let components = URLComponents(url: url, resolvingAgainstBaseURL: false),
                   let queryItems = components.queryItems else { return false }
             return queryItems.contains(where: { $0.name == "uri" })
         } ?? false
@@ -124,15 +131,8 @@ final class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         let url = context.url
         print("🔗 [PayDeeplink] openURLContexts - Received URL: \(url.absoluteString)")
 
-        // Check for payment deep link and handle if found
-        if let paymentLink = extractPaymentLink(from: url) {
-            handlePaymentLink(paymentLink)
-            // For POS scan format (walletconnectpay host), return early - no pairing needed
-            if url.host == "walletconnectpay" {
-                return
-            }
-            // For new format (uri with pay param), continue to pairing flow
-            print("🔗 [PayDeeplink] Continuing to pairing flow...")
+        if handleIncomingURL(url) {
+            return
         }
 
         do {
@@ -171,6 +171,22 @@ final class SceneDelegate: UIResponder, UIWindowSceneDelegate {
 }
 
 private extension SceneDelegate {
+    @discardableResult
+    func handleIncomingURL(_ url: URL) -> Bool {
+        guard let paymentLink = extractPaymentLink(from: url) else {
+            return false
+        }
+
+        handlePaymentLink(paymentLink)
+
+        if containsWalletConnectURI(in: url) {
+            print("🔗 [PayDeeplink] Continuing to pairing flow...")
+            return false
+        }
+
+        // Mirror the Paste URL flow for direct payment links: start Pay only.
+        return true
+    }
 
     func configureWalletKitClientIfNeeded() {
         Networking.configure(
@@ -220,11 +236,13 @@ private extension SceneDelegate {
         return isPayLink
     }
 
-    /// Extract payment link from a URL if present
-    /// Supports two formats:
+    /// Extract payment link from a URL if present.
+    /// Supports:
     /// - WC URI format: `uri` parameter containing embedded `pay` param
-    /// - POS scan format: `walletconnectpay` host with `paymentId` query param (scanned directly from POS)
-    /// - Returns: The payment link string if found, nil otherwise
+    /// - Gateway / universal links with `pid` or `paymentId` query params
+    /// - App deeplinks with `walletconnectpay?paymentId=...`
+    /// Returns the same payment string that the manual Paste URL flow would pass
+    /// to the Pay modal whenever possible.
     private func extractPaymentLink(from url: URL) -> String? {
         print("🔗 [PayDeeplink] Extracting payment link from: \(url.absoluteString)")
 
@@ -242,15 +260,33 @@ private extension SceneDelegate {
             return uriValue
         }
 
-        // POS scan format: walletconnectpay host with paymentId (scanned directly from POS)
+        // App deeplink format: extract the bare payment ID instead of forwarding the
+        // custom walletapp:// URL, which Pay rejects.
         if url.host == "walletconnectpay",
-           let paymentId = queryItems.first(where: { $0.name == "paymentId" })?.value {
-            print("🔗 [PayDeeplink] POS scan format - paymentId: \(paymentId)")
-            return "walletapp://walletconnectpay?paymentId=\(paymentId)"
+           let paymentId = queryItems.first(where: { $0.name == "paymentId" })?.value,
+           !paymentId.isEmpty {
+            print("🔗 [PayDeeplink] App deeplink format - paymentId: \(paymentId)")
+            return paymentId
+        }
+
+        // For gateway / universal links, preserve the original URL exactly.
+        if let paymentId = queryItems.first(where: { $0.name == "paymentId" || $0.name == "pid" })?.value,
+           !paymentId.isEmpty {
+            print("🔗 [PayDeeplink] Found paymentId in URL query: \(paymentId)")
+            return url.absoluteString
         }
 
         print("🔗 [PayDeeplink] No payment link found in URL")
         return nil
+    }
+
+    private func containsWalletConnectURI(in url: URL) -> Bool {
+        guard let components = URLComponents(url: url, resolvingAgainstBaseURL: false),
+              let uriValue = components.queryItems?.first(where: { $0.name == "uri" })?.value else {
+            return false
+        }
+
+        return !uriValue.isEmpty
     }
     
     /// Handle a payment link URL via the coordinator
@@ -259,4 +295,3 @@ private extension SceneDelegate {
         coordinator.showPayment(paymentLink: paymentLink)
     }
 }
-

--- a/Example/WalletApp/Common/Navigation/NavigationCoordinator.swift
+++ b/Example/WalletApp/Common/Navigation/NavigationCoordinator.swift
@@ -98,8 +98,11 @@ final class NavigationCoordinator: ObservableObject {
         let address = importAccount.account.address
         let accounts = [
             "eip155:1:\(address)",
+            "eip155:10:\(address)",
+            "eip155:56:\(address)",
             "eip155:137:\(address)",
-            "eip155:8453:\(address)"
+            "eip155:8453:\(address)",
+            "eip155:42161:\(address)"
         ]
 
         if activeModal != nil {

--- a/Example/WalletApp/Common/ScanOptionsHandler.swift
+++ b/Example/WalletApp/Common/ScanOptionsHandler.swift
@@ -5,12 +5,21 @@ import Combine
 /// Manages the sheet state and handles scan QR / paste URL actions.
 final class ScanOptionsHandler: ObservableObject {
     @Published var showScanOptions = false
+    @Published var testModeUrl: String = ""
 
     /// Override for scan camera presentation (set by coordinator)
     var onScanOverride: (() -> Void)?
 
     private let onScan: () -> Void
     private let onUri: (String) -> Void
+
+    var isTestMode: Bool {
+        #if ENABLE_TEST_MODE
+        return true
+        #else
+        return false
+        #endif
+    }
 
     init(onScan: @escaping () -> Void, onUri: @escaping (String) -> Void) {
         self.onScan = onScan
@@ -41,6 +50,16 @@ final class ScanOptionsHandler: ObservableObject {
         showScanOptions = false
         DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) { [weak self] in
             self?.onUri(clipboard)
+        }
+    }
+
+    func submitTestUrl() {
+        let url = testModeUrl.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !url.isEmpty else { return }
+        showScanOptions = false
+        testModeUrl = ""
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) { [weak self] in
+            self?.onUri(url)
         }
     }
 }

--- a/Example/WalletApp/Common/Views/HeaderView.swift
+++ b/Example/WalletApp/Common/Views/HeaderView.swift
@@ -33,7 +33,7 @@ struct HeaderView: View {
                     .background(AppColors.backgroundInvert)
                     .cornerRadius(CGFloat(AppRadius._3))
             }
-            .accessibilityIdentifier("headerScan")
+            .accessibilityIdentifier("button-scan")
         }
         .padding(.horizontal, Spacing._5)
         .padding(.bottom, Spacing._2)

--- a/Example/WalletApp/Common/Views/ModalComponents.swift
+++ b/Example/WalletApp/Common/Views/ModalComponents.swift
@@ -110,9 +110,10 @@ struct CloseIconShape: Shape {
 /// 38x38 button with 1px border, X icon 20x20
 struct ModalCloseButton: View {
     let action: () -> Void
+    var accessibilityId: String? = nil
 
     var body: some View {
-        Button(action: action) {
+        let button = Button(action: action) {
             CloseIconShape()
                 .fill(AppColors.textPrimary)
                 .frame(width: 20, height: 20)
@@ -123,6 +124,11 @@ struct ModalCloseButton: View {
                         .stroke(AppColors.borderSecondary, lineWidth: 1)
                 )
                 .cornerRadius(Spacing._3)
+        }
+        if let accessibilityId {
+            button.accessibilityIdentifier(accessibilityId)
+        } else {
+            button
         }
     }
 }
@@ -146,6 +152,7 @@ struct ModalContainer<Content: View>: View {
         .padding(.bottom, Spacing._5)
         .background(AppColors.backgroundPrimary)
         .cornerRadius(AppRadius._8)
+        .accessibilityElement(children: .contain)
     }
 }
 
@@ -157,11 +164,13 @@ struct ModalHeaderBar: View {
     var backAction: (() -> Void)?
     var closeAction: () -> Void
     var leadingContent: AnyView?
+    var backAccessibilityId: String? = nil
+    var closeAccessibilityId: String? = nil
 
     var body: some View {
         HStack {
             if showBack, let backAction {
-                ModalBackButton(action: backAction)
+                ModalBackButton(action: backAction, accessibilityId: backAccessibilityId)
             }
 
             if let leadingContent {
@@ -170,7 +179,7 @@ struct ModalHeaderBar: View {
 
             Spacer()
 
-            ModalCloseButton(action: closeAction)
+            ModalCloseButton(action: closeAction, accessibilityId: closeAccessibilityId)
         }
         .padding(.top, Spacing._4)
     }
@@ -250,14 +259,20 @@ struct CopyIconShape: Shape {
 /// Reusable back arrow button
 struct ModalBackButton: View {
     let action: () -> Void
+    var accessibilityId: String? = nil
 
     var body: some View {
-        Button(action: action) {
+        let button = Button(action: action) {
             Image(systemName: "arrow.left")
                 .appFont(.lg, weight: .medium)
                 .foregroundColor(AppColors.textPrimary)
                 .frame(width: 38, height: 38)
                 .cornerRadius(Spacing._3)
+        }
+        if let accessibilityId {
+            button.accessibilityIdentifier(accessibilityId)
+        } else {
+            button
         }
     }
 }

--- a/Example/WalletApp/Common/Views/ScannerOptionsView.swift
+++ b/Example/WalletApp/Common/Views/ScannerOptionsView.swift
@@ -4,6 +4,7 @@ struct ScannerOptionsView: View {
     let onScanQR: () -> Void
     let onPasteURL: () -> Void
     let onClose: () -> Void
+    @ObservedObject var scanHandler: ScanOptionsHandler
 
     var body: some View {
         VStack(spacing: Spacing._5) {
@@ -32,6 +33,29 @@ struct ScannerOptionsView: View {
                     },
                     action: onPasteURL
                 )
+
+                #if ENABLE_TEST_MODE
+                // Test mode: visible text input for Maestro E2E tests
+                VStack(spacing: 8) {
+                    TextField("Enter URL", text: $scanHandler.testModeUrl)
+                        .textFieldStyle(.roundedBorder)
+                        .autocapitalization(.none)
+                        .disableAutocorrection(true)
+                        .accessibilityIdentifier("input-paste-url")
+
+                    Button(action: { scanHandler.submitTestUrl() }) {
+                        Text("Submit URL")
+                            .appFont(.lg)
+                            .foregroundColor(AppColors.textInvert)
+                            .frame(maxWidth: .infinity)
+                            .frame(height: 48)
+                            .background(AppColors.backgroundInvert)
+                            .cornerRadius(Spacing._3)
+                    }
+                    .accessibilityIdentifier("button-submit-url")
+                }
+                .padding(.top, 8)
+                #endif
             }
         }
         .padding(.horizontal, Spacing._5)
@@ -68,6 +92,7 @@ struct ScannerOptionsView: View {
 extension View {
     func scanOptionsSheet(
         isPresented: Binding<Bool>,
+        scanHandler: ScanOptionsHandler,
         onScanQR: @escaping () -> Void,
         onPasteURL: @escaping () -> Void
     ) -> some View {
@@ -75,11 +100,16 @@ extension View {
             ScannerOptionsView(
                 onScanQR: onScanQR,
                 onPasteURL: onPasteURL,
-                onClose: { isPresented.wrappedValue = false }
+                onClose: { isPresented.wrappedValue = false },
+                scanHandler: scanHandler
             )
             .ignoresSafeArea()
             .presentationDragIndicator(.hidden)
+            #if ENABLE_TEST_MODE
+            .presentationDetents([.height(400)])
+            #else
             .presentationDetents([.height(258)])
+            #endif
             .sheetBackground()
         }
     }

--- a/Example/WalletApp/Other/Info.plist
+++ b/Example/WalletApp/Other/Info.plist
@@ -44,6 +44,8 @@
 	<string>$(PIMLICO_API_KEY)</string>
 	<key>PROJECT_ID</key>
 	<string>$(PROJECT_ID)</string>
+	<key>TEST_WALLET_PRIVATE_KEY</key>
+	<string>$(TEST_WALLET_PRIVATE_KEY)</string>
 	<key>RPC_URL</key>
 	<string>$(RPC_URL)</string>
 	<key>SIMULATOR_IDENTIFIER</key>

--- a/Example/WalletApp/PresentationLayer/Wallet/Balances/BalancesView.swift
+++ b/Example/WalletApp/PresentationLayer/Wallet/Balances/BalancesView.swift
@@ -187,6 +187,7 @@ struct BalancesView: View {
         }
         .scanOptionsSheet(
             isPresented: $viewModel.scanHandler.showScanOptions,
+            scanHandler: viewModel.scanHandler,
             onScanQR: { viewModel.scanHandler.scanQR() },
             onPasteURL: { viewModel.scanHandler.pasteURL() }
         )

--- a/Example/WalletApp/PresentationLayer/Wallet/Pay/PayComponents.swift
+++ b/Example/WalletApp/PresentationLayer/Wallet/Pay/PayComponents.swift
@@ -189,7 +189,7 @@ struct PayPrimaryButton: View {
     let title: String
     var isEnabled: Bool = true
     var isLoading: Bool = false
-    var accessibilityId: String = ""
+    var accessibilityId: String?
     let action: () -> Void
 
     var body: some View {
@@ -208,7 +208,7 @@ struct PayPrimaryButton: View {
         .buttonStyle(PrimaryButtonStyle())
         .accessibilityElement(children: .ignore)
         .accessibilityLabel(title)
-        .accessibilityIdentifier(accessibilityId)
+        .accessibilityIdentifier(accessibilityId ?? "")
         .opacity(isEnabled ? 1.0 : 0.5)
         .disabled(!isEnabled || isLoading)
     }

--- a/Example/WalletApp/PresentationLayer/Wallet/Pay/PayComponents.swift
+++ b/Example/WalletApp/PresentationLayer/Wallet/Pay/PayComponents.swift
@@ -189,6 +189,7 @@ struct PayPrimaryButton: View {
     let title: String
     var isEnabled: Bool = true
     var isLoading: Bool = false
+    var accessibilityId: String = ""
     let action: () -> Void
 
     var body: some View {
@@ -205,6 +206,9 @@ struct PayPrimaryButton: View {
             }
         }
         .buttonStyle(PrimaryButtonStyle())
+        .accessibilityElement(children: .ignore)
+        .accessibilityLabel(title)
+        .accessibilityIdentifier(accessibilityId)
         .opacity(isEnabled ? 1.0 : 0.5)
         .disabled(!isEnabled || isLoading)
     }

--- a/Example/WalletApp/PresentationLayer/Wallet/Pay/PayConfirmingView.swift
+++ b/Example/WalletApp/PresentationLayer/Wallet/Pay/PayConfirmingView.swift
@@ -18,6 +18,7 @@ struct PayConfirmingView: View {
             Text(presenter.loadingMessage)
                 .appFont(.h6)
                 .foregroundColor(AppColors.textPrimary)
+                .accessibilityIdentifier("pay-loading-message")
 
             Spacer()
                 .frame(height: Spacing._7) // 28px + 20px container padding = 48px total

--- a/Example/WalletApp/PresentationLayer/Wallet/Pay/PayContainerView.swift
+++ b/Example/WalletApp/PresentationLayer/Wallet/Pay/PayContainerView.swift
@@ -9,6 +9,7 @@ struct PayContainerView: View {
             ZStack {
                 Color.black.opacity(0.6)
                     .ignoresSafeArea()
+                    .accessibilityHidden(true)
                     .onTapGesture {
                         // Dismiss keyboard when tapping background
                         UIApplication.shared.sendAction(#selector(UIResponder.resignFirstResponder), to: nil, from: nil, for: nil)
@@ -32,7 +33,8 @@ struct PayContainerView: View {
                             if let url = presenter.buildICWebViewURL() {
                                 PayDataCollectionWebView(
                                     url: url,
-                                    onClose: { presenter.goBack() },
+                                    onBack: { presenter.goBack() },
+                                    onClose: { presenter.dismiss() },
                                     onComplete: { presenter.onICWebViewComplete() },
                                     onError: { error in presenter.onICWebViewError(error) }
                                 )
@@ -54,6 +56,7 @@ struct PayContainerView: View {
                     }
                     .transition(.opacity)
                     .id(presenter.currentStep)
+                    .accessibilityElement(children: .contain)
                 }
                 .animation(.easeInOut(duration: 0.25), value: presenter.currentStep)
             }

--- a/Example/WalletApp/PresentationLayer/Wallet/Pay/PayDataCollectionWebView.swift
+++ b/Example/WalletApp/PresentationLayer/Wallet/Pay/PayDataCollectionWebView.swift
@@ -3,6 +3,7 @@ import WebKit
 
 struct PayDataCollectionWebView: View {
     let url: URL
+    let onBack: () -> Void
     let onClose: () -> Void
     let onComplete: () -> Void
     let onError: (String) -> Void
@@ -10,7 +11,7 @@ struct PayDataCollectionWebView: View {
     @State private var isLoading = true
 
     var body: some View {
-        ZStack(alignment: .topTrailing) {
+        ZStack(alignment: .top) {
             PayWebViewRepresentable(
                 url: url,
                 isLoading: $isLoading,
@@ -18,10 +19,14 @@ struct PayDataCollectionWebView: View {
                 onError: onError
             )
 
-            // Close button — matches other Pay modals
-            PayCloseButton(action: onClose)
-                .padding(.top, Spacing._4)
-                .padding(.trailing, Spacing._5)
+            // Header bar with back + close buttons
+            HStack {
+                PayBackButton(action: onBack, accessibilityId: "pay-button-back")
+                Spacer()
+                PayCloseButton(action: onClose, accessibilityId: "pay-button-close")
+            }
+            .padding(.top, Spacing._4)
+            .padding(.horizontal, Spacing._5)
 
             if isLoading {
                 VStack {
@@ -178,6 +183,7 @@ struct PayDataCollectionWebView_Previews: PreviewProvider {
     static var previews: some View {
         PayDataCollectionWebView(
             url: URL(string: "https://example.com")!,
+            onBack: {},
             onClose: {},
             onComplete: {},
             onError: { _ in }

--- a/Example/WalletApp/PresentationLayer/Wallet/Pay/PayOptionsView.swift
+++ b/Example/WalletApp/PresentationLayer/Wallet/Pay/PayOptionsView.swift
@@ -12,26 +12,30 @@ struct PayOptionsView: View {
                     PayQuestionButton(action: {
                         presenter.showWhyInfoRequiredScreen()
                     })
+                    .accessibilityIdentifier("pay-button-info")
                 }
 
                 Spacer()
 
-                PayCloseButton(action: { presenter.dismiss() })
+                PayCloseButton(action: { presenter.dismiss() }, accessibilityId: "pay-button-close")
             }
             .padding(.top, Spacing._5)
 
             if let info = presenter.paymentInfo {
                 // Merchant icon (no seal check)
                 MerchantHeader(info: info)
+                    .accessibilityIdentifier("pay-merchant-info")
                     .padding(.top, Spacing._5)
 
                 // Payment options list
                 VStack(spacing: Spacing._2) {
-                    ForEach(presenter.paymentOptions, id: \.id) { option in
+                    ForEach(Array(presenter.paymentOptions.enumerated()), id: \.element.id) { index, option in
+                        let isSelected = presenter.selectedOption?.id == option.id
                         PaymentOptionCard(
                             option: option,
-                            isSelected: presenter.selectedOption?.id == option.id,
+                            isSelected: isSelected,
                             requiresIC: presenter.anyOptionRequiresIC,
+                            accessibilityId: isSelected ? "pay-option-\(index)-selected" : "pay-option-\(index)",
                             onSelect: { presenter.selectOption(option) }
                         )
                     }
@@ -42,6 +46,7 @@ struct PayOptionsView: View {
                 PayPrimaryButton(
                     title: presenter.optionsButtonTitle,
                     isEnabled: presenter.selectedOption != nil,
+                    accessibilityId: "pay-button-continue",
                     action: { presenter.continueFromOptions() }
                 )
                 .padding(.top, Spacing._5)
@@ -102,6 +107,7 @@ struct PaymentOptionCard: View {
     let option: PaymentOption
     let isSelected: Bool
     let requiresIC: Bool
+    let accessibilityId: String
     let onSelect: () -> Void
 
     var body: some View {
@@ -126,7 +132,10 @@ struct PaymentOptionCard: View {
 
                 // "Info required" pill
                 if requiresIC {
-                    InfoRequiredPillView(isSelected: isSelected)
+                    InfoRequiredPillView(
+                        isSelected: isSelected,
+                        accessibilityId: "pay-info-required-badge"
+                    )
                 }
             }
             .padding(Spacing._5)
@@ -137,6 +146,9 @@ struct PaymentOptionCard: View {
                     .stroke(isSelected ? AppColors.borderAccentPrimary : Color.clear, lineWidth: 1)
             )
         }
+        .accessibilityIdentifier(accessibilityId)
+        .accessibilityLabel(option.amount.display.networkName ?? "unknown")
+        .accessibilityElement(children: .contain)
     }
 }
 
@@ -227,6 +239,7 @@ struct TokenIcon: View {
 
 struct InfoRequiredPill: UIViewRepresentable {
     let isSelected: Bool
+    let accessibilityId: String?
 
     func makeUIView(context: Context) -> UILabel {
         let label = UILabel()
@@ -234,6 +247,9 @@ struct InfoRequiredPill: UIViewRepresentable {
         label.textAlignment = .center
         label.setContentHuggingPriority(.required, for: .horizontal)
         label.setContentCompressionResistancePriority(.required, for: .horizontal)
+        label.isAccessibilityElement = true
+        label.accessibilityLabel = "Info required"
+        label.accessibilityIdentifier = accessibilityId
         return label
     }
 
@@ -242,6 +258,7 @@ struct InfoRequiredPill: UIViewRepresentable {
         let textInvert = UIColor { $0.userInterfaceStyle == .dark ? UIColor(hex: 0x202020) : UIColor(hex: 0xFFFFFF) }
         let textPrimary = UIColor { $0.userInterfaceStyle == .dark ? UIColor(hex: 0xFFFFFF) : UIColor(hex: 0x202020) }
         label.textColor = isSelected ? textInvert : textPrimary
+        label.accessibilityIdentifier = accessibilityId
     }
 }
 
@@ -249,9 +266,10 @@ struct InfoRequiredPill: UIViewRepresentable {
 
 struct InfoRequiredPillView: View {
     let isSelected: Bool
+    let accessibilityId: String?
 
     var body: some View {
-        InfoRequiredPill(isSelected: isSelected)
+        InfoRequiredPill(isSelected: isSelected, accessibilityId: accessibilityId)
             .fixedSize()
             .padding(.horizontal, Spacing._2)
             .padding(.vertical, 6)

--- a/Example/WalletApp/PresentationLayer/Wallet/Pay/PayPresenter.swift
+++ b/Example/WalletApp/PresentationLayer/Wallet/Pay/PayPresenter.swift
@@ -69,17 +69,9 @@ final class PayPresenter: ObservableObject {
         collectData != nil
     }
 
-    /// Whether the currently selected option requires information capture
-    var selectedOptionRequiresIC: Bool {
-        collectData != nil
-    }
-
-    /// Button title for the options screen — "Continue" if IC required, "Pay $X" otherwise
+    /// Button title for the options screen — "Continue"
     var optionsButtonTitle: String {
-        if selectedOptionRequiresIC {
-            return "Continue"
-        }
-        return "Pay \(paymentInfo?.formattedAmount ?? "")"
+        return "Continue"
     }
 
     init(paymentLink: String, accounts: [String], importAccount: ImportAccount) {
@@ -112,10 +104,15 @@ final class PayPresenter: ObservableObject {
                 } else {
                     // Select first option by default
                     self.selectedOption = response.options.first
-                    self.currentStep = .options
+                    // Auto-skip to summary for single option with no IC
+                    if response.options.count == 1 && response.collectData == nil {
+                        self.currentStep = .summary
+                    } else {
+                        self.currentStep = .options
+                    }
                 }
             } catch {
-                self.resultType = Self.detectErrorType(from: error.localizedDescription)
+                self.resultType = Self.detectResultType(from: error)
                 self.currentStep = .result
             }
         }
@@ -141,22 +138,51 @@ final class PayPresenter: ObservableObject {
 
     /// Called when IC WebView encounters an error
     func onICWebViewError(_ error: String) {
-        errorMessage = "Information capture failed: \(error)"
-        showError = true
+        let detectedType = Self.detectErrorType(from: error)
+        switch detectedType {
+        case .generic:
+            errorMessage = "Information capture failed: \(error)"
+            showError = true
+        default:
+            resultType = detectedType
+            currentStep = .result
+        }
     }
 
-    /// Build IC WebView URL with domain validation
+    /// Build IC WebView URL with domain validation, prefill data, and theme
     func buildICWebViewURL() -> URL? {
         guard let baseUrlString = collectData?.url,
               !baseUrlString.isEmpty,
-              let url = URL(string: baseUrlString),
-              let host = url.host,
+              var components = URLComponents(string: baseUrlString),
+              let host = components.host,
               Self.trustedICDomains.contains(host) else {
             print("⚠️ [Pay] Rejected untrusted or invalid IC URL: \(collectData?.url ?? "nil")")
             return nil
         }
 
-        return url
+        // Prefill data
+        let prefillData: [String: String] = [
+            "fullName": "John Doe",
+            "dob": "1990-06-15",
+            "pobAddress": "Buenos Aires"
+        ]
+
+        if let jsonData = try? JSONSerialization.data(withJSONObject: prefillData) {
+            let base64 = jsonData.base64EncodedString()
+            var queryItems = components.queryItems ?? []
+            // Replace existing prefill param if present, otherwise add
+            if let idx = queryItems.firstIndex(where: { $0.name == "prefill" }) {
+                queryItems[idx] = URLQueryItem(name: "prefill", value: base64)
+            } else {
+                queryItems.append(URLQueryItem(name: "prefill", value: base64))
+            }
+            // Append theme param
+            let theme = ThemeManager.shared.isDarkMode ? "dark" : "light"
+            queryItems.append(URLQueryItem(name: "theme", value: theme))
+            components.queryItems = queryItems
+        }
+
+        return components.url
     }
 
     func goBack() {
@@ -239,7 +265,7 @@ final class PayPresenter: ObservableObject {
                 case .succeeded, .processing:
                     self.resultType = .success
                 case .cancelled:
-                    self.resultType = .generic(message: "This payment was cancelled.")
+                    self.resultType = .cancelled
                 case .failed:
                     self.resultType = .generic(message: "Payment failed.")
                 case .expired:
@@ -253,7 +279,7 @@ final class PayPresenter: ObservableObject {
                 NotificationCenter.default.post(name: .paymentCompleted, object: nil)
 
             } catch {
-                self.resultType = Self.detectErrorType(from: error.localizedDescription)
+                self.resultType = Self.detectResultType(from: error)
                 self.currentStep = .result
             }
         }
@@ -263,7 +289,45 @@ final class PayPresenter: ObservableObject {
         dismissAction?()
     }
 
-    // MARK: - Error Detection (from RN utils.ts)
+    // MARK: - Error Detection
+
+    /// Map SDK typed errors to result types, with string fallback
+    static func detectResultType(from error: Error) -> PayResultType {
+        // Match on typed SDK errors first
+        if let e = error as? GetPaymentOptionsError {
+            switch e {
+            case .PaymentExpired:
+                return .expired
+            case .PaymentNotFound(let msg):
+                // Cancelled payments may surface as NotFound — check inner message
+                let lowered = msg.lowercased()
+                if lowered.contains("cancelled") || lowered.contains("canceled") {
+                    return .cancelled
+                }
+                return .notFound
+            default:
+                break
+            }
+        }
+        if let e = error as? ConfirmPaymentError {
+            switch e {
+            case .PaymentExpired, .RouteExpired, .QuoteExpired:
+                return .expired
+            case .PaymentNotFound(let msg):
+                let lowered = msg.lowercased()
+                if lowered.contains("cancelled") || lowered.contains("canceled") {
+                    return .cancelled
+                }
+                return .notFound
+            case .PollingTimeout:
+                return .expired
+            default:
+                break
+            }
+        }
+        // Fallback: string matching on localizedDescription
+        return detectErrorType(from: error.localizedDescription)
+    }
 
     static func detectErrorType(from message: String) -> PayResultType {
         let lowered = message.lowercased()
@@ -272,6 +336,9 @@ final class PayPresenter: ObservableObject {
         }
         if lowered.contains("expired") || lowered.contains("timeout") {
             return .expired
+        }
+        if lowered.contains("cancelled") || lowered.contains("canceled") {
+            return .cancelled
         }
         if lowered.contains("not found") || lowered.contains("404") {
             return .notFound

--- a/Example/WalletApp/PresentationLayer/Wallet/Pay/PayPresenter.swift
+++ b/Example/WalletApp/PresentationLayer/Wallet/Pay/PayPresenter.swift
@@ -163,19 +163,11 @@ final class PayPresenter: ObservableObject {
         var queryItems = components.queryItems ?? []
 
         #if ENABLE_TEST_MODE
-        // Prefill data — only used in test builds
-        let prefillData: [String: String] = [
-            "fullName": "John Doe",
-            "dob": "1990-06-15",
-            "pobAddress": "Buenos Aires"
-        ]
-
-        if let jsonData = try? JSONSerialization.data(withJSONObject: prefillData) {
-            let base64 = jsonData.base64EncodedString()
+        if let prefill = buildPrefillParam(schema: collectData?.schema) {
             if let idx = queryItems.firstIndex(where: { $0.name == "prefill" }) {
-                queryItems[idx] = URLQueryItem(name: "prefill", value: base64)
+                queryItems[idx] = URLQueryItem(name: "prefill", value: prefill)
             } else {
-                queryItems.append(URLQueryItem(name: "prefill", value: base64))
+                queryItems.append(URLQueryItem(name: "prefill", value: prefill))
             }
         }
         #endif
@@ -187,6 +179,59 @@ final class PayPresenter: ObservableObject {
 
         return components.url
     }
+
+    #if ENABLE_TEST_MODE
+    /// Build Base64-encoded prefill param from schema's required fields.
+    /// Parses the JSON Schema to find all required fields (top-level + anyOf)
+    /// and only includes fields that have known prefill values.
+    private func buildPrefillParam(schema: String?) -> String? {
+        guard let schema = schema,
+              let schemaData = schema.data(using: .utf8),
+              let schemaJson = try? JSONSerialization.jsonObject(with: schemaData) as? [String: Any] else {
+            return nil
+        }
+
+        // Collect required fields from top-level "required" array
+        var requiredFields = Set<String>()
+        if let topRequired = schemaJson["required"] as? [String] {
+            requiredFields.formUnion(topRequired)
+        }
+
+        // Collect required fields from "anyOf" conditional groups
+        if let anyOf = schemaJson["anyOf"] as? [[String: Any]] {
+            for group in anyOf {
+                if let groupRequired = group["required"] as? [String] {
+                    requiredFields.formUnion(groupRequired)
+                }
+            }
+        }
+
+        // Map of field id -> prefill value
+        let fieldValues: [String: String] = [
+            "fullName": "Test User",
+            "dob": "1990-01-15",
+            "pobAddress": "New York, NY",
+            "pobCountry": "US",
+            "porAddress": "New York, NY",
+            "porCountry": "US"
+        ]
+
+        // Build prefill dict with only required fields
+        var prefillData = [String: String]()
+        for fieldId in requiredFields {
+            if let value = fieldValues[fieldId] {
+                prefillData[fieldId] = value
+            }
+        }
+
+        guard !prefillData.isEmpty,
+              let jsonData = try? JSONSerialization.data(withJSONObject: prefillData) else {
+            return nil
+        }
+
+        return jsonData.base64EncodedString()
+    }
+    #endif
 
     func goBack() {
         switch currentStep {

--- a/Example/WalletApp/PresentationLayer/Wallet/Pay/PayPresenter.swift
+++ b/Example/WalletApp/PresentationLayer/Wallet/Pay/PayPresenter.swift
@@ -160,7 +160,10 @@ final class PayPresenter: ObservableObject {
             return nil
         }
 
-        // Prefill data
+        var queryItems = components.queryItems ?? []
+
+        #if ENABLE_TEST_MODE
+        // Prefill data — only used in test builds
         let prefillData: [String: String] = [
             "fullName": "John Doe",
             "dob": "1990-06-15",
@@ -169,18 +172,18 @@ final class PayPresenter: ObservableObject {
 
         if let jsonData = try? JSONSerialization.data(withJSONObject: prefillData) {
             let base64 = jsonData.base64EncodedString()
-            var queryItems = components.queryItems ?? []
-            // Replace existing prefill param if present, otherwise add
             if let idx = queryItems.firstIndex(where: { $0.name == "prefill" }) {
                 queryItems[idx] = URLQueryItem(name: "prefill", value: base64)
             } else {
                 queryItems.append(URLQueryItem(name: "prefill", value: base64))
             }
-            // Append theme param
-            let theme = ThemeManager.shared.isDarkMode ? "dark" : "light"
-            queryItems.append(URLQueryItem(name: "theme", value: theme))
-            components.queryItems = queryItems
         }
+        #endif
+
+        // Append theme param
+        let theme = ThemeManager.shared.isDarkMode ? "dark" : "light"
+        queryItems.append(URLQueryItem(name: "theme", value: theme))
+        components.queryItems = queryItems
 
         return components.url
     }

--- a/Example/WalletApp/PresentationLayer/Wallet/Pay/PayPresenter.swift
+++ b/Example/WalletApp/PresentationLayer/Wallet/Pay/PayPresenter.swift
@@ -162,7 +162,6 @@ final class PayPresenter: ObservableObject {
 
         var queryItems = components.queryItems ?? []
 
-        #if ENABLE_TEST_MODE
         if let prefill = buildPrefillParam(schema: collectData?.schema) {
             if let idx = queryItems.firstIndex(where: { $0.name == "prefill" }) {
                 queryItems[idx] = URLQueryItem(name: "prefill", value: prefill)
@@ -170,7 +169,6 @@ final class PayPresenter: ObservableObject {
                 queryItems.append(URLQueryItem(name: "prefill", value: prefill))
             }
         }
-        #endif
 
         // Append theme param
         let theme = ThemeManager.shared.isDarkMode ? "dark" : "light"
@@ -180,7 +178,6 @@ final class PayPresenter: ObservableObject {
         return components.url
     }
 
-    #if ENABLE_TEST_MODE
     /// Build Base64-encoded prefill param from schema's required fields.
     /// Parses the JSON Schema to find all required fields (top-level + anyOf)
     /// and only includes fields that have known prefill values.
@@ -231,7 +228,6 @@ final class PayPresenter: ObservableObject {
 
         return jsonData.base64EncodedString()
     }
-    #endif
 
     func goBack() {
         switch currentStep {

--- a/Example/WalletApp/PresentationLayer/Wallet/Pay/PayResultView.swift
+++ b/Example/WalletApp/PresentationLayer/Wallet/Pay/PayResultView.swift
@@ -1,10 +1,12 @@
 import SwiftUI
+import UIKit
 
 /// Error type classification matching RN's ResultView error states
 enum PayResultType {
     case success
     case insufficientFunds
     case expired
+    case cancelled
     case notFound
     case generic(message: String)
 
@@ -24,7 +26,7 @@ struct PayResultView: View {
             // Close button
             HStack {
                 Spacer()
-                PayCloseButton(action: { presenter.dismiss() })
+                PayCloseButton(action: { presenter.dismiss() }, accessibilityId: "pay-button-close")
             }
             .padding(.top, Spacing._4)
 
@@ -32,7 +34,12 @@ struct PayResultView: View {
                 .frame(height: Spacing._7)
 
             // Icon (not animated, matches RN)
-            iconView
+            ResultIconImageView(
+                image: iconImage,
+                accessibilityId: iconAccessibilityId,
+                accessibilityLabel: iconAccessibilityLabel
+            )
+            .frame(width: 40, height: 40)
 
             Spacer()
                 .frame(height: Spacing._4)
@@ -43,6 +50,7 @@ struct PayResultView: View {
                 .foregroundColor(AppColors.textPrimary)
                 .multilineTextAlignment(.center)
                 .lineLimit(2)
+                .accessibilityIdentifier("pay-result-title")
 
             // Message (error states only)
             if let message = message {
@@ -60,18 +68,20 @@ struct PayResultView: View {
             // Action button
             PayPrimaryButton(
                 title: buttonTitle,
+                accessibilityId: buttonAccessibilityId,
                 action: { presenter.dismiss() }
             )
 
             Spacer()
                 .frame(height: Spacing._2)
         }
+        .accessibilityIdentifier("pay-result-container")
     }
 
     // MARK: - Icon
 
     @ViewBuilder
-    private var iconView: some View {
+    private var iconSourceView: some View {
         switch presenter.resultType {
         case .success:
             CheckCircleShape()
@@ -83,11 +93,18 @@ struct PayResultView: View {
                 .fill(AppColors.iconAccentPrimary)
                 .frame(width: 40, height: 40)
 
-        case .expired, .notFound, .generic:
+        case .cancelled, .expired, .notFound, .generic:
             WarningCircleShape()
                 .fill(AppColors.iconAccentPrimary)
                 .frame(width: 40, height: 40)
         }
+    }
+
+    private var iconImage: UIImage? {
+        let renderer = ImageRenderer(content: iconSourceView)
+        renderer.scale = UIScreen.main.scale
+        renderer.proposedSize = ProposedViewSize(width: 40, height: 40)
+        return renderer.uiImage
     }
 
     // MARK: - Text Content
@@ -102,6 +119,8 @@ struct PayResultView: View {
             return "Not enough funds"
         case .expired:
             return "Payment expired"
+        case .cancelled:
+            return "Payment cancelled"
         case .notFound:
             return "Payment not found"
         case .generic:
@@ -117,6 +136,8 @@ struct PayResultView: View {
             return "You don't have enough crypto to complete this payment."
         case .expired:
             return "This payment took too long to approve and has expired."
+        case .cancelled:
+            return "This payment was cancelled."
         case .notFound:
             return "This payment link is not valid or has already been completed."
         case .generic(let msg):
@@ -130,11 +151,82 @@ struct PayResultView: View {
             return "Got it!"
         case .expired:
             return "Scan new QR code"
+        case .cancelled:
+            return "Close"
         case .notFound, .generic:
             return "Close"
         }
     }
 
+    // MARK: - Accessibility IDs
+
+    private var iconAccessibilityId: String {
+        switch presenter.resultType {
+        case .success:
+            return "pay-result-success-icon"
+        case .insufficientFunds:
+            return "pay-result-insufficient-funds-icon"
+        case .expired:
+            return "pay-result-expired-icon"
+        case .cancelled:
+            return "pay-result-cancelled-icon"
+        case .notFound, .generic:
+            return "pay-result-error-icon"
+        }
+    }
+
+    private var iconAccessibilityLabel: String {
+        switch presenter.resultType {
+        case .success:
+            return "Success"
+        case .insufficientFunds:
+            return "Insufficient funds"
+        case .expired:
+            return "Expired"
+        case .cancelled:
+            return "Cancelled"
+        case .notFound, .generic:
+            return "Error"
+        }
+    }
+
+    private var buttonAccessibilityId: String {
+        switch presenter.resultType {
+        case .success:
+            return "pay-button-result-action-success"
+        case .insufficientFunds:
+            return "pay-button-result-action-insufficient_funds"
+        case .expired:
+            return "pay-button-result-action-expired"
+        case .cancelled:
+            return "pay-button-result-action-cancelled"
+        case .notFound, .generic:
+            return "pay-button-result-action-generic"
+        }
+    }
+
+}
+
+private struct ResultIconImageView: UIViewRepresentable {
+    let image: UIImage?
+    let accessibilityId: String
+    let accessibilityLabel: String
+
+    func makeUIView(context: Context) -> UIImageView {
+        let imageView = UIImageView()
+        imageView.contentMode = .scaleAspectFit
+        imageView.isAccessibilityElement = true
+        imageView.accessibilityTraits = .image
+        imageView.accessibilityIdentifier = accessibilityId
+        imageView.accessibilityLabel = accessibilityLabel
+        return imageView
+    }
+
+    func updateUIView(_ imageView: UIImageView, context: Context) {
+        imageView.image = image
+        imageView.accessibilityIdentifier = accessibilityId
+        imageView.accessibilityLabel = accessibilityLabel
+    }
 }
 
 #if DEBUG

--- a/Example/WalletApp/PresentationLayer/Wallet/Pay/PaySummaryView.swift
+++ b/Example/WalletApp/PresentationLayer/Wallet/Pay/PaySummaryView.swift
@@ -6,12 +6,19 @@ struct PaySummaryView: View {
 
     var body: some View {
         PayModalContainer {
-            // Header: X close (right only)
-            PayHeaderBar(closeAction: { presenter.dismiss() })
+            // Header: back (left) + X close (right)
+            PayHeaderBar(
+                showBack: true,
+                backAction: { presenter.goBack() },
+                closeAction: { presenter.dismiss() },
+                backAccessibilityId: "pay-button-back",
+                closeAccessibilityId: "pay-button-close"
+            )
 
             if let info = presenter.paymentInfo {
                 // Merchant header
                 MerchantHeader(info: info)
+                    .accessibilityIdentifier("pay-merchant-info")
                     .padding(.top, Spacing._4)
 
                 // "Pay with" row
@@ -41,6 +48,7 @@ struct PaySummaryView: View {
                     .frame(height: 68)
                     .background(AppColors.foregroundPrimary)
                     .cornerRadius(AppRadius._4)
+                    .accessibilityIdentifier("pay-review-token-\(option.amount.display.networkName ?? "unknown")")
                     .padding(.top, Spacing._6)
                 }
 
@@ -50,6 +58,7 @@ struct PaySummaryView: View {
                 // Pay button
                 PayPrimaryButton(
                     title: "Pay \(info.formattedAmount)",
+                    accessibilityId: "pay-button-pay",
                     action: { presenter.confirmPayment() }
                 )
                 .padding(.bottom, Spacing._2)

--- a/Example/WalletApp/PresentationLayer/Wallet/Pay/PayWhyInfoRequiredView.swift
+++ b/Example/WalletApp/PresentationLayer/Wallet/Pay/PayWhyInfoRequiredView.swift
@@ -9,7 +9,9 @@ struct PayWhyInfoRequiredView: View {
             PayHeaderBar(
                 showBack: true,
                 backAction: { presenter.goBack() },
-                closeAction: { presenter.dismiss() }
+                closeAction: { presenter.dismiss() },
+                backAccessibilityId: "pay-button-back",
+                closeAccessibilityId: "pay-button-close"
             )
 
             Spacer()

--- a/Example/WalletApp/PresentationLayer/Wallet/Pay/README.md
+++ b/Example/WalletApp/PresentationLayer/Wallet/Pay/README.md
@@ -77,16 +77,105 @@ walletapp://walletconnectpay?paymentId=<payment-id>
 
 ## Testing
 
-### Using the Card Button
+### Manual Testing
+
+#### Using the Card Button
 1. Press the credit card button on the main wallet screen
 2. Paste a payment URL like: `https://wc-pay-buyer-experience-dev.walletconnect-v1-bridge.workers.dev/?pid=pay_xxx`
 3. Click "Start Payment" to begin the flow
 
-### Using Deep Link
+#### Using Deep Link
 ```bash
 # Test deep link in simulator
 xcrun simctl openurl booted "walletapp://walletconnectpay?paymentId=test-123"
 ```
+
+### Maestro E2E Tests
+
+The Pay flow has comprehensive E2E tests using [Maestro](https://maestro.mobile.dev). Test flows are shared across all platforms (Swift, Kotlin, React Native) via the [`WalletConnect/actions`](https://github.com/WalletConnect/actions) repo.
+
+#### Prerequisites
+
+1. Install Maestro: `curl -Ls "https://get.maestro.mobile.dev" | bash`
+2. Copy `.env.maestro.example` to `.env.maestro` at the repo root and fill in merchant credentials
+3. Have an iOS simulator booted
+
+#### Quick Start
+
+```bash
+# Download shared test flows
+./scripts/setup-maestro-pay-tests.sh
+
+# Build with test mode (adds URL input field + optional pre-funded wallet)
+xcodebuild \
+  -project "Example/ExampleApp.xcodeproj" \
+  -scheme "WalletApp" \
+  -destination "platform=iOS Simulator,name=iPhone 16" \
+  -derivedDataPath DerivedDataCache \
+  RELAY_HOST='relay.walletconnect.com' \
+  PROJECT_ID='<your-project-id>' \
+  TEST_WALLET_PRIVATE_KEY='<your-funded-wallet-private-key>' \
+  SWIFT_ACTIVE_COMPILATION_CONDITIONS='$(inherited) ENABLE_TEST_MODE' \
+  build
+
+# Install on simulator
+xcrun simctl install booted "$(find DerivedDataCache -name 'WalletApp.app' -path '*/Debug-iphonesimulator/*' | head -1)"
+
+# Run all Pay tests
+./scripts/run-maestro-pay-tests.sh
+
+# Or run a single test
+./scripts/run-maestro-pay-tests.sh .maestro/pay_expired_link.yaml
+
+# Or pass arbitrary Maestro args
+./scripts/run-maestro-pay-tests.sh --device <sim-udid> .maestro/pay_expired_link.yaml
+
+# Interactive debugging — inspect the view hierarchy
+maestro studio
+```
+
+#### Test Mode (`ENABLE_TEST_MODE`)
+
+The `ENABLE_TEST_MODE` Swift compilation flag enables two features:
+
+1. **URL text input**: Adds a visible text field to the scanner options sheet, allowing Maestro to type payment URLs directly instead of scanning QR codes.
+2. **Test wallet import**: If `TEST_WALLET_PRIVATE_KEY` is provided as a build setting, the app imports that EVM private key on launch instead of generating a random wallet. This allows CI to use a pre-funded wallet for Pay tests.
+
+Both are passed via xcodebuild build settings — no Xcode project changes needed.
+
+#### Accessibility Identifiers
+
+All Pay views have accessibility identifiers that the shared Maestro test flows rely on. Key IDs:
+
+| ID | View | Element |
+|----|------|---------|
+| `button-scan` | HeaderView | Scan button |
+| `input-paste-url` | ScannerOptionsView | URL text field (test mode) |
+| `button-submit-url` | ScannerOptionsView | Submit URL button (test mode) |
+| `pay-merchant-info` | PayOptionsView / PaySummaryView | Merchant header |
+| `pay-option-{index}` | PayOptionsView | Unselected option card |
+| `pay-option-{index}-selected` | PayOptionsView | Selected option card |
+| `pay-info-required-badge` | PayOptionsView | "Info required" pill |
+| `pay-button-info` | PayOptionsView | Question mark button |
+| `pay-button-continue` | PayOptionsView | Continue/Pay button |
+| `pay-button-close` | All Pay views | Close (X) button |
+| `pay-button-back` | PaySummaryView / PayWhyInfoRequiredView | Back arrow button |
+| `pay-review-token-{networkName}` | PaySummaryView | Selected token row |
+| `pay-button-pay` | PaySummaryView | Pay button |
+| `pay-loading-message` | PayConfirmingView | Loading text |
+| `pay-result-container` | PayResultView | Result container |
+| `pay-result-success-icon` | PayResultView | Success checkmark |
+| `pay-result-insufficient-funds-icon` | PayResultView | Insufficient funds icon |
+| `pay-result-expired-icon` | PayResultView | Expired icon |
+| `pay-result-cancelled-icon` | PayResultView | Cancelled icon |
+| `pay-result-error-icon` | PayResultView | Generic error icon |
+| `pay-button-result-action-{type}` | PayResultView | Result action button |
+
+These IDs must stay in sync with `WalletConnect/actions/maestro/pay-tests`. If you change the UI, update the IDs accordingly.
+
+#### CI
+
+The GitHub Actions workflow `.github/workflows/ci_e2e_pay_tests.yml` runs these tests automatically on PRs. It builds with `ENABLE_TEST_MODE`, boots an iOS simulator, and runs the full Pay test suite.
 
 ## Yttrium Types
 
@@ -111,4 +200,3 @@ The following types from Yttrium are used directly (no FFI wrappers needed):
 - [ ] Add success/failure confirmation screens
 - [ ] Handle payment expiration gracefully
 - [ ] Publish yttrium version with Pay types (then set `yttriumDebug = false`)
-

--- a/Example/WalletApp/PresentationLayer/Wallet/Settings/SettingsView.swift
+++ b/Example/WalletApp/PresentationLayer/Wallet/Settings/SettingsView.swift
@@ -60,6 +60,7 @@ struct SettingsView: View {
         }
         .scanOptionsSheet(
             isPresented: $viewModel.scanHandler.showScanOptions,
+            scanHandler: viewModel.scanHandler,
             onScanQR: { viewModel.scanHandler.scanQR() },
             onPasteURL: { viewModel.scanHandler.pasteURL() }
         )

--- a/Example/WalletApp/PresentationLayer/Wallet/Wallet/WalletView.swift
+++ b/Example/WalletApp/PresentationLayer/Wallet/Wallet/WalletView.swift
@@ -113,6 +113,7 @@ struct WalletView: View {
         }
         .scanOptionsSheet(
             isPresented: $presenter.scanHandler.showScanOptions,
+            scanHandler: presenter.scanHandler,
             onScanQR: { presenter.scanHandler.scanQR() },
             onPasteURL: { presenter.scanHandler.pasteURL() }
         )

--- a/Example/WalletApp/WalletApp.entitlements
+++ b/Example/WalletApp/WalletApp.entitlements
@@ -7,6 +7,9 @@
 	<key>com.apple.developer.associated-domains</key>
 	<array>
 		<string>applinks:lab.reown.com</string>
+		<string>applinks:pay.walletconnect.com</string>
+		<string>applinks:staging.pay.walletconnect.com</string>
+		<string>applinks:dev.pay.walletconnect.com</string>
 	</array>
 	<key>com.apple.developer.usernotifications.communication</key>
 	<true/>

--- a/Example/WalletApp/WalletAppRelease.entitlements
+++ b/Example/WalletApp/WalletAppRelease.entitlements
@@ -7,6 +7,9 @@
 	<key>com.apple.developer.associated-domains</key>
 	<array>
 		<string>applinks:lab.reown.com</string>
+		<string>applinks:pay.walletconnect.com</string>
+		<string>applinks:staging.pay.walletconnect.com</string>
+		<string>applinks:dev.pay.walletconnect.com</string>
 	</array>
 	<key>com.apple.developer.usernotifications.communication</key>
 	<true/>

--- a/scripts/run-maestro-pay-tests.sh
+++ b/scripts/run-maestro-pay-tests.sh
@@ -52,10 +52,9 @@ if [ ! -f "$ENV_FILE" ]; then
 fi
 
 echo "Loading credentials from $ENV_FILE"
-set -a
-# shellcheck disable=SC1090
-source "$ENV_FILE"
-set +a
+while IFS='=' read -r key value; do
+  [[ "$key" =~ ^[A-Z_][A-Z0-9_]*$ ]] && export "$key=$value"
+done < <(grep -E '^[A-Z_][A-Z0-9_]*=' "$ENV_FILE")
 
 REQUIRED_VARS=(
   WPAY_CUSTOMER_KEY_SINGLE_NOKYC

--- a/scripts/run-maestro-pay-tests.sh
+++ b/scripts/run-maestro-pay-tests.sh
@@ -1,0 +1,113 @@
+#!/bin/bash
+# Runs Maestro Pay E2E tests with the required environment variables.
+# Reads secrets from .env.maestro file (create one from .env.maestro.example).
+#
+# Usage: ./scripts/run-maestro-pay-tests.sh [maestro-args...]
+# Examples:
+#   ./scripts/run-maestro-pay-tests.sh
+#   ./scripts/run-maestro-pay-tests.sh .maestro/pay_cancelled.yaml
+#   ./scripts/run-maestro-pay-tests.sh pay_cancelled.yaml
+#   ACTIONS_BRANCH=feat/my-branch ./scripts/run-maestro-pay-tests.sh
+#   ./scripts/run-maestro-pay-tests.sh --device <sim-udid> .maestro/pay_expired_link.yaml
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+ROOT_DIR="$(dirname "$SCRIPT_DIR")"
+MAESTRO_DIR="$ROOT_DIR/.maestro"
+ENV_FILE="$ROOT_DIR/.env.maestro"
+
+resolve_maestro_path() {
+  local value="$1"
+
+  if [ -f "$value" ] || [ -d "$value" ]; then
+    printf '%s\n' "$value"
+    return 0
+  fi
+
+  if [ -f "$ROOT_DIR/$value" ] || [ -d "$ROOT_DIR/$value" ]; then
+    printf '%s\n' "$ROOT_DIR/$value"
+    return 0
+  fi
+
+  if [ -f "$MAESTRO_DIR/$value" ] || [ -d "$MAESTRO_DIR/$value" ]; then
+    printf '%s\n' "$MAESTRO_DIR/$value"
+    return 0
+  fi
+
+  return 1
+}
+
+# Download pay test flows if not present.
+if ! ls "$MAESTRO_DIR"/pay_*.yaml >/dev/null 2>&1; then
+  echo "Pay test flows not found. Downloading..."
+  "$SCRIPT_DIR/setup-maestro-pay-tests.sh" "${ACTIONS_BRANCH:-master}"
+fi
+
+if [ ! -f "$ENV_FILE" ]; then
+  echo "Missing $ENV_FILE. Create one from .env.maestro.example:"
+  echo "  cp .env.maestro.example .env.maestro"
+  echo "  # Then fill in the values"
+  exit 1
+fi
+
+echo "Loading credentials from $ENV_FILE"
+set -a
+# shellcheck disable=SC1090
+source "$ENV_FILE"
+set +a
+
+REQUIRED_VARS=(
+  WPAY_CUSTOMER_KEY_SINGLE_NOKYC
+  WPAY_MERCHANT_ID_SINGLE_NOKYC
+  WPAY_CUSTOMER_KEY_MULTI_NOKYC
+  WPAY_MERCHANT_ID_MULTI_NOKYC
+  WPAY_CUSTOMER_KEY_MULTI_KYC
+  WPAY_MERCHANT_ID_MULTI_KYC
+)
+
+MISSING=()
+for var in "${REQUIRED_VARS[@]}"; do
+  if [ -z "${!var:-}" ]; then
+    MISSING+=("$var")
+  fi
+done
+
+if [ ${#MISSING[@]} -gt 0 ]; then
+  echo "Missing required variables in $ENV_FILE:"
+  printf '  %s\n' "${MISSING[@]}"
+  exit 1
+fi
+
+APP_ID="${MAESTRO_APP_ID:-${APP_ID:-com.walletconnect.walletapp}}"
+
+MAESTRO_ARGS=(
+  --env "APP_ID=$APP_ID"
+  --env "WPAY_CUSTOMER_KEY_SINGLE_NOKYC=$WPAY_CUSTOMER_KEY_SINGLE_NOKYC"
+  --env "WPAY_MERCHANT_ID_SINGLE_NOKYC=$WPAY_MERCHANT_ID_SINGLE_NOKYC"
+  --env "WPAY_CUSTOMER_KEY_MULTI_NOKYC=$WPAY_CUSTOMER_KEY_MULTI_NOKYC"
+  --env "WPAY_MERCHANT_ID_MULTI_NOKYC=$WPAY_MERCHANT_ID_MULTI_NOKYC"
+  --env "WPAY_CUSTOMER_KEY_MULTI_KYC=$WPAY_CUSTOMER_KEY_MULTI_KYC"
+  --env "WPAY_MERCHANT_ID_MULTI_KYC=$WPAY_MERCHANT_ID_MULTI_KYC"
+)
+
+if [ $# -eq 0 ]; then
+  set -- --include-tags pay "$MAESTRO_DIR"
+fi
+
+RESOLVED_ARGS=()
+for arg in "$@"; do
+  if [[ "$arg" == -* ]]; then
+    RESOLVED_ARGS+=("$arg")
+  elif resolved_path="$(resolve_maestro_path "$arg")"; then
+    RESOLVED_ARGS+=("$resolved_path")
+  else
+    RESOLVED_ARGS+=("$arg")
+  fi
+done
+
+echo "Running Maestro Pay E2E tests..."
+echo "  App ID: $APP_ID"
+echo "  Args: ${RESOLVED_ARGS[*]}"
+
+maestro test "${MAESTRO_ARGS[@]}" "${RESOLVED_ARGS[@]}"

--- a/scripts/setup-maestro-pay-tests.sh
+++ b/scripts/setup-maestro-pay-tests.sh
@@ -1,0 +1,51 @@
+#!/bin/bash
+# Downloads shared WalletConnect Pay Maestro test flows from WalletConnect/actions repo.
+# Usage: ./scripts/setup-maestro-pay-tests.sh [ref]
+#   ref: actions repo branch/tag/commit to pull from (default: master)
+
+set -euo pipefail
+
+REF="${1:-master}"
+REPO="WalletConnect/actions"
+TARGET_DIR=".maestro"
+TMP_DIR="$(mktemp -d)"
+
+cleanup() {
+  rm -rf "$TMP_DIR"
+}
+trap cleanup EXIT
+
+count_matches() {
+  local dir="$1"
+  local pattern="$2"
+  find "$dir" -maxdepth 1 -type f -name "$pattern" | wc -l | tr -d ' '
+}
+
+echo "Downloading Maestro Pay test flows from $REPO@$REF..."
+
+mkdir -p "$TARGET_DIR" "$TARGET_DIR/flows" "$TARGET_DIR/scripts"
+
+# Remove only managed Pay flow files so unrelated local Maestro files survive.
+find "$TARGET_DIR" -maxdepth 1 -type f -name 'pay_*.yaml' -delete
+find "$TARGET_DIR/flows" -maxdepth 1 -type f -name 'pay_*.yaml' -delete
+find "$TARGET_DIR/scripts" -maxdepth 1 -type f -name '*.js' -delete
+
+# Download and extract the archive. codeload accepts branches, tags, and commit SHAs.
+curl -fsSL "https://codeload.github.com/$REPO/tar.gz/$REF" | tar -xz -C "$TMP_DIR"
+
+SRC_DIR="$(find "$TMP_DIR" -type d -path '*/maestro/pay-tests/.maestro' | head -1)"
+if [ -z "$SRC_DIR" ]; then
+  echo "ERROR: Could not find maestro/pay-tests/.maestro in the archive"
+  exit 1
+fi
+
+cp "$SRC_DIR"/pay_*.yaml "$TARGET_DIR/"
+mkdir -p "$TARGET_DIR/flows"
+cp "$SRC_DIR"/flows/pay_*.yaml "$TARGET_DIR/flows/"
+mkdir -p "$TARGET_DIR/scripts"
+cp "$SRC_DIR"/scripts/*.js "$TARGET_DIR/scripts/"
+
+echo "Pay test flows copied to $TARGET_DIR/"
+echo "  $(count_matches "$TARGET_DIR" 'pay_*.yaml') root flows"
+echo "  $(count_matches "$TARGET_DIR/flows" 'pay_*.yaml') sub-flows"
+echo "  $(count_matches "$TARGET_DIR/scripts" '*.js') scripts"


### PR DESCRIPTION
## Summary
- fix WalletApp Pay accessibility and modal exposure so Maestro can reliably find and tap result, badge, and action elements
- fix Pay universal/deep-link handling so opening payment links follows the same flow as pasting a URL and starts the correct payment
- add local Maestro Pay helpers, env template, CI workflow, and updated docs for running shared pay tests

## Testing
- bash -n scripts/setup-maestro-pay-tests.sh
- bash -n scripts/run-maestro-pay-tests.sh
- xcodebuild -project "Example/ExampleApp.xcodeproj" -scheme "WalletApp" -destination 'platform=iOS Simulator,OS=26.2,name=iPhone 17' -derivedDataPath DerivedDataCache RELAY_HOST='relay.walletconnect.com' PROJECT_ID='test-project-id' TEST_WALLET_PRIVATE_KEY='test-wallet-private-key' SWIFT_ACTIVE_COMPILATION_CONDITIONS='$(inherited) ENABLE_TEST_MODE' build