### PR TITLE
chore: update yttrium to 0.10.52

### DIFF
--- a/Example/ExampleApp.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Example/ExampleApp.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -276,8 +276,8 @@
         "repositoryURL": "https://github.com/reown-com/yttrium",
         "state": {
           "branch": null,
-          "revision": "c670309e6593875ba8211b9722d465b92d7ea2cf",
-          "version": "0.10.50"
+          "revision": "083e30289e343b80f8b171fcadcabb71dd967bf2",
+          "version": "0.10.52"
         }
       }
     ]

--- a/Package.resolved
+++ b/Package.resolved
@@ -60,8 +60,8 @@
         "repositoryURL": "https://github.com/reown-com/yttrium",
         "state": {
           "branch": null,
-          "revision": "c670309e6593875ba8211b9722d465b92d7ea2cf",
-          "version": "0.10.50"
+          "revision": "083e30289e343b80f8b171fcadcabb71dd967bf2",
+          "version": "0.10.52"
         }
       }
     ]

--- a/Package.swift
+++ b/Package.swift
@@ -17,7 +17,7 @@ var dependencies: [Package.Dependency] = [
 if yttriumDebug {
     dependencies.append(.package(path: "../yttrium"))
 } else {
-    dependencies.append(.package(url: "https://github.com/reown-com/yttrium", .exact("0.10.50")))
+    dependencies.append(.package(url: "https://github.com/reown-com/yttrium", .exact("0.10.52")))
 }
 
 let yttriumTarget = buildYttriumWrapperTarget()

--- a/reown-swift.podspec
+++ b/reown-swift.podspec
@@ -1,7 +1,7 @@
 require "json"
 
 package = JSON.parse(File.read(File.join(__dir__, "Sources/WalletConnectRelay/PackageConfig.json")))
-yttrium_version = '0.10.50'
+yttrium_version = '0.10.52'
 
 Pod::Spec.new do |spec|
 


### PR DESCRIPTION
## Summary
- Update Yttrium dependency from `0.10.50` to `0.10.52` across SPM and CocoaPods
- Updates `Package.swift`, `Package.resolved`, `reown-swift.podspec`, and Example app resolved packages

## Release
https://github.com/reown-com/yttrium/releases/tag/0.10.52

## Test plan
- [ ] Verify SPM resolution succeeds (`swift package resolve`)
- [ ] Verify CocoaPods integration works (`pod install`)
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)