### PR TITLE
ci(pay): drop Maestro --debug-output and filter uploaded artifacts

### DIFF
--- a/.github/workflows/ci_e2e_pay_tests.yml
+++ b/.github/workflows/ci_e2e_pay_tests.yml
@@ -95,7 +95,6 @@ jobs:
             --env WPAY_MERCHANT_ID_MULTI_KYC=${{ secrets.WPAY_MERCHANT_ID_MULTI_KYC }} \
             --include-tags pay \
             --test-output-dir debug-artifacts/maestro-output \
-            --debug-output debug-artifacts/maestro-debug \
             .maestro/
 
       - name: Capture simulator logs
@@ -108,7 +107,15 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: maestro-pay-test-artifacts
-          path: debug-artifacts/
+          path: |
+            debug-artifacts/**/*.png
+            debug-artifacts/**/*.jpg
+            debug-artifacts/**/*.jpeg
+            debug-artifacts/**/*.mp4
+            debug-artifacts/**/*.mov
+            debug-artifacts/**/*.webm
+            debug-artifacts/**/*.gif
+            debug-artifacts/sim-logs.logarchive
           retention-days: 14
           if-no-files-found: ignore
 

--- a/.github/workflows/ci_e2e_pay_tests.yml
+++ b/.github/workflows/ci_e2e_pay_tests.yml
@@ -59,10 +59,10 @@ jobs:
             | xcbeautify
 
       - name: Copy shared Pay test flows
-        uses: WalletConnect/actions/maestro/pay-tests@f9522878950f7bd904a628b2c4d486b93034a4fe # main
+        uses: WalletConnect/actions/maestro/pay-tests@0c9875ae33fe85fa6a4110dc46c82876d91a551d # main
 
       - name: Install Maestro
-        uses: WalletConnect/actions/maestro/setup@f9522878950f7bd904a628b2c4d486b93034a4fe # main
+        uses: WalletConnect/actions/maestro/setup@0c9875ae33fe85fa6a4110dc46c82876d91a551d # main
         with:
           version: '2.4.0'
 


### PR DESCRIPTION
# Description

Maestro's `--debug-output` produces `commands-*.json` and `ai-report-*.html` files that embed every `--env` value passed to the run, including our `WPAY_CUSTOMER_KEY_*` / `WPAY_MERCHANT_ID_*` secrets. Those files are currently picked up by the unscoped `debug-artifacts/` upload, so anyone with read access to the workflow artifacts can retrieve the secrets.

This change:
- Drops the `--debug-output debug-artifacts/maestro-debug` flag from the Maestro invocation so the sensitive debug files are never produced.
- Restricts the `maestro-pay-test-artifacts` upload to media (png/jpg/jpeg/mp4/mov/webm/gif) plus `sim-logs.logarchive`, matching the iOS-side follow-up described in reown-com/react-native-examples#475.

Resolves # (issue)

## How Has This Been Tested?

- [ ] Trigger `Maestro E2E Pay Tests` on this branch and confirm the job still passes.
- [ ] Download `maestro-pay-test-artifacts` and verify no `commands-*.json` / `ai-report-*.html` files are present.

## Due Dilligence

* [ ] Breaking change
* [ ] Requires a documentation update

🤖 Generated with [Claude Code](https://claude.com/claude-code)