### PR TITLE
feat(pay): support Permit2 two-action payment flow

### DIFF
--- a/Example/ExampleApp.xcodeproj/project.pbxproj
+++ b/Example/ExampleApp.xcodeproj/project.pbxproj
@@ -260,6 +260,9 @@
 		PAY0000012EE100000000000E /* PayOptionsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = PAY0000022EE100000000000E /* PayOptionsView.swift */; };
 		PAY0000012EE100000000000F /* PayWhyInfoRequiredView.swift in Sources */ = {isa = PBXBuildFile; fileRef = PAY0000022EE100000000000F /* PayWhyInfoRequiredView.swift */; };
 		PAY0000012EE1000000000010 /* PaySummaryView.swift in Sources */ = {isa = PBXBuildFile; fileRef = PAY0000022EE1000000000010 /* PaySummaryView.swift */; };
+		PAY0000012EE1000000000020 /* PaymentUtil.swift in Sources */ = {isa = PBXBuildFile; fileRef = PAY0000022EE1000000000020 /* PaymentUtil.swift */; };
+		PAY0000012EE1000000000021 /* PayRPCClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = PAY0000022EE1000000000021 /* PayRPCClient.swift */; };
+		PAY0000012EE1000000000022 /* PayTransactionService.swift in Sources */ = {isa = PBXBuildFile; fileRef = PAY0000022EE1000000000022 /* PayTransactionService.swift */; };
 		PH6B000100000000000001 /* WalletGenerationService.swift in Sources */ = {isa = PBXBuildFile; fileRef = PH6F000100000000000001 /* WalletGenerationService.swift */; };
 		PH6B000100000000000002 /* ThemeManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = PH6F000100000000000002 /* ThemeManager.swift */; };
 		PH6B000100000000000003 /* SettingsCardView.swift in Sources */ = {isa = PBXBuildFile; fileRef = PH6F000100000000000003 /* SettingsCardView.swift */; };
@@ -271,6 +274,7 @@
 		SCNH000100000000000000AA /* ScanOptionsHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = SCNH000200000000000000AA /* ScanOptionsHandler.swift */; };
 		SESSD3TA11000000000000B1 /* SessionDetailModalView.swift in Sources */ = {isa = PBXBuildFile; fileRef = SESSD3TA11000000000000F1 /* SessionDetailModalView.swift */; };
 		SIGNTD0001000000000001 /* SignTypedDataSigner.swift in Sources */ = {isa = PBXBuildFile; fileRef = SIGNTD0002000000000001 /* SignTypedDataSigner.swift */; };
+		EIP71200010000000001 /* EIP712TypedData.swift in Sources */ = {isa = PBXBuildFile; fileRef = EIP71200020000000001 /* EIP712TypedData.swift */; };
 		WTST000100000000000000AA /* WalletToast.swift in Sources */ = {isa = PBXBuildFile; fileRef = WTST000200000000000000AA /* WalletToast.swift */; };
 /* End PBXBuildFile section */
 
@@ -533,6 +537,9 @@
 		PAY0000022EE100000000000E /* PayOptionsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PayOptionsView.swift; sourceTree = "<group>"; };
 		PAY0000022EE100000000000F /* PayWhyInfoRequiredView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PayWhyInfoRequiredView.swift; sourceTree = "<group>"; };
 		PAY0000022EE1000000000010 /* PaySummaryView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaySummaryView.swift; sourceTree = "<group>"; };
+		PAY0000022EE1000000000020 /* PaymentUtil.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaymentUtil.swift; sourceTree = "<group>"; };
+		PAY0000022EE1000000000021 /* PayRPCClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PayRPCClient.swift; sourceTree = "<group>"; };
+		PAY0000022EE1000000000022 /* PayTransactionService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PayTransactionService.swift; sourceTree = "<group>"; };
 		PH6F000100000000000001 /* WalletGenerationService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WalletGenerationService.swift; sourceTree = "<group>"; };
 		PH6F000100000000000002 /* ThemeManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThemeManager.swift; sourceTree = "<group>"; };
 		PH6F000100000000000003 /* SettingsCardView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsCardView.swift; sourceTree = "<group>"; };
@@ -544,6 +551,7 @@
 		SCNH000200000000000000AA /* ScanOptionsHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScanOptionsHandler.swift; sourceTree = "<group>"; };
 		SESSD3TA11000000000000F1 /* SessionDetailModalView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionDetailModalView.swift; sourceTree = "<group>"; };
 		SIGNTD0002000000000001 /* SignTypedDataSigner.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SignTypedDataSigner.swift; sourceTree = "<group>"; };
+		EIP71200020000000001 /* EIP712TypedData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EIP712TypedData.swift; sourceTree = "<group>"; };
 		WTST000200000000000000AA /* WalletToast.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WalletToast.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -897,6 +905,7 @@
 				44D89A102DF183C800056A7B /* SuiSigner.swift */,
 				A57E71A5291CF76400325797 /* ETHSigner.swift */,
 				SIGNTD0002000000000001 /* SignTypedDataSigner.swift */,
+				EIP71200020000000001 /* EIP712TypedData.swift */,
 				A57E71A7291CF8A500325797 /* SOLSigner.swift */,
 				44650A3E2E951D71004F2144 /* TonSigner.swift */,
 				44650A422F1E0002004F2144 /* TronSigner.swift */,
@@ -1458,6 +1467,9 @@
 				PAY0000022EE1000000000010 /* PaySummaryView.swift */,
 				PAY0000022EE100000000000C /* PayConfirmingView.swift */,
 				PAY0000022EE100000000000D /* PayDataCollectionWebView.swift */,
+				PAY0000022EE1000000000020 /* PaymentUtil.swift */,
+				PAY0000022EE1000000000021 /* PayRPCClient.swift */,
+				PAY0000022EE1000000000022 /* PayTransactionService.swift */,
 			);
 			path = Pay;
 			sourceTree = "<group>";
@@ -2034,6 +2046,9 @@
 				PAY0000012EE1000000000010 /* PaySummaryView.swift in Sources */,
 				PAY0000012EE100000000000C /* PayConfirmingView.swift in Sources */,
 				PAY0000012EE100000000000D /* PayDataCollectionWebView.swift in Sources */,
+				PAY0000012EE1000000000020 /* PaymentUtil.swift in Sources */,
+				PAY0000012EE1000000000021 /* PayRPCClient.swift in Sources */,
+				PAY0000012EE1000000000022 /* PayTransactionService.swift in Sources */,
 				44650A3F2E951D71004F2144 /* TonSigner.swift in Sources */,
 				44650A432F1E0002004F2144 /* TronSigner.swift in Sources */,
 				CA00CA032F3A0001000CA101 /* CantonSigner.swift in Sources */,
@@ -2042,6 +2057,7 @@
 				A5D610CE2AB3594100C20083 /* ListingsAPI.swift in Sources */,
 				C5B2F6FB297055B0000DBA0E /* ETHSigner.swift in Sources */,
 				SIGNTD0001000000000001 /* SignTypedDataSigner.swift in Sources */,
+				EIP71200010000000001 /* EIP712TypedData.swift in Sources */,
 				A5D610D42AB35BED00C20083 /* FailableDecodable.swift in Sources */,
 				A56AC8F22AD88A5A001C8FAA /* Sequence.swift in Sources */,
 				A50B6A382B06697B00162B01 /* ProfilingService.swift in Sources */,

--- a/Example/Shared/AccountStorage.swift
+++ b/Example/Shared/AccountStorage.swift
@@ -23,4 +23,11 @@ final class AccountStorage {
             UserDefaults.standard.set(newValue?.storageId, forKey: "account")
         }
     }
+
+    /// True once the user imports a wallet via the Settings UI. Used to prevent
+    /// `TEST_WALLET_PRIVATE_KEY` from overwriting a manually-imported wallet on subsequent launches.
+    var userImportedWallet: Bool {
+        get { UserDefaults.standard.bool(forKey: "userImportedWallet") }
+        set { UserDefaults.standard.set(newValue, forKey: "userImportedWallet") }
+    }
 }

--- a/Example/Shared/Signer/EIP712TypedData.swift
+++ b/Example/Shared/Signer/EIP712TypedData.swift
@@ -1,0 +1,290 @@
+import Foundation
+import BigInt
+import CryptoSwift
+
+/// Minimal EIP-712 typed-data hasher.
+///
+/// Parses a `{types, primaryType, domain, message}` JSON object and produces the
+/// 32-byte signing digest:
+///   `keccak256(0x1901 || hashStruct("EIP712Domain", domain) || hashStruct(primaryType, message))`
+///
+/// Supports every EIP-712 encodable type we expect from merchant payment flows
+/// (Permit2, ERC-3009, etc.): primitives (`address`, `bool`, `uint*`, `int*`,
+/// `bytes`, `string`, `bytesN`), nested structs, and arrays (`T[]` / `T[N]`).
+struct EIP712TypedData {
+    struct Field {
+        let name: String
+        let type: String
+    }
+
+    let types: [String: [Field]]
+    let primaryType: String
+    let domain: Any
+    let message: Any
+
+    static func parse(jsonString: String) throws -> EIP712TypedData {
+        guard let data = jsonString.data(using: .utf8),
+              let root = try JSONSerialization.jsonObject(with: data) as? [String: Any] else {
+            throw EIP712Error.invalidJSON
+        }
+        guard let typesRaw = root["types"] as? [String: [[String: Any]]] else {
+            throw EIP712Error.missing("types")
+        }
+        guard let primary = root["primaryType"] as? String else {
+            throw EIP712Error.missing("primaryType")
+        }
+        guard let domain = root["domain"] else { throw EIP712Error.missing("domain") }
+        guard let message = root["message"] else { throw EIP712Error.missing("message") }
+
+        var parsedTypes: [String: [Field]] = [:]
+        for (name, fields) in typesRaw {
+            parsedTypes[name] = fields.compactMap { f -> Field? in
+                guard let n = f["name"] as? String, let t = f["type"] as? String else { return nil }
+                return Field(name: n, type: t)
+            }
+        }
+        return EIP712TypedData(
+            types: parsedTypes,
+            primaryType: primary,
+            domain: domain,
+            message: message
+        )
+    }
+
+    func digest() throws -> [UInt8] {
+        let domainSep = try hashStruct(type: "EIP712Domain", data: domain)
+        let messageHash = try hashStruct(type: primaryType, data: message)
+        var buf: [UInt8] = [0x19, 0x01]
+        buf.append(contentsOf: domainSep)
+        buf.append(contentsOf: messageHash)
+        return Self.keccak256(buf)
+    }
+
+    // MARK: - Struct + type encoding
+
+    private func hashStruct(type: String, data: Any) throws -> [UInt8] {
+        var buf = typeHash(of: type)
+        buf.append(contentsOf: try encodeData(type: type, data: data))
+        return Self.keccak256(buf)
+    }
+
+    private func typeHash(of type: String) -> [UInt8] {
+        Self.keccak256(Array(encodeType(of: type).utf8))
+    }
+
+    private func encodeType(of type: String) -> String {
+        var deps = dependencies(of: type, collected: Set([type]))
+        deps.remove(type)
+        let ordered = [type] + deps.sorted()
+        return ordered.map { name -> String in
+            let fields = types[name] ?? []
+            let body = fields.map { "\($0.type) \($0.name)" }.joined(separator: ",")
+            return "\(name)(\(body))"
+        }.joined()
+    }
+
+    private func dependencies(of type: String, collected: Set<String>) -> Set<String> {
+        guard let fields = types[type] else { return collected }
+        var result = collected
+        for f in fields {
+            let base = Self.baseType(f.type)
+            if types[base] != nil, !result.contains(base) {
+                result.insert(base)
+                result.formUnion(dependencies(of: base, collected: result))
+            }
+        }
+        return result
+    }
+
+    private static func baseType(_ type: String) -> String {
+        if let idx = type.firstIndex(of: "[") { return String(type[..<idx]) }
+        return type
+    }
+
+    private func encodeData(type: String, data: Any) throws -> [UInt8] {
+        guard let fields = types[type] else { throw EIP712Error.unknownType(type) }
+        guard let dict = data as? [String: Any] else { throw EIP712Error.expectedObject(type) }
+        var buf: [UInt8] = []
+        for f in fields {
+            let encoded = try encodeValue(type: f.type, value: dict[f.name])
+            buf.append(contentsOf: encoded)
+        }
+        return buf
+    }
+
+    /// Encode a single value into its 32-byte EIP-712 word (or keccak256 of
+    /// concatenated encodings for arrays / dynamic types).
+    private func encodeValue(type: String, value: Any?) throws -> [UInt8] {
+        if type.hasSuffix("]") {
+            guard let openIdx = type.lastIndex(of: "[") else {
+                throw EIP712Error.invalidType(type)
+            }
+            let inner = String(type[..<openIdx])
+            guard let array = value as? [Any] else { throw EIP712Error.expectedArray(type) }
+            var buf: [UInt8] = []
+            for el in array {
+                buf.append(contentsOf: try encodeValue(type: inner, value: el))
+            }
+            return Self.keccak256(buf)
+        }
+
+        if types[type] != nil {
+            guard let value else { throw EIP712Error.missing(type) }
+            return try hashStruct(type: type, data: value)
+        }
+
+        guard let value else { throw EIP712Error.missing(type) }
+        switch type {
+        case "address":
+            return try encodeAddress(value)
+        case "bool":
+            return try encodeBool(value)
+        case "string":
+            let s = (value as? String) ?? ""
+            return Self.keccak256(Array(s.utf8))
+        case "bytes":
+            let bytes = try parseBytes(value)
+            return Self.keccak256(bytes)
+        default:
+            if type.hasPrefix("uint") {
+                return try encodeUInt(value)
+            }
+            if type.hasPrefix("int") {
+                return try encodeInt(value)
+            }
+            if type.hasPrefix("bytes") {
+                let raw = try parseBytes(value)
+                if raw.count > 32 { throw EIP712Error.invalidType(type) }
+                return raw + Array(repeating: 0, count: 32 - raw.count)
+            }
+            throw EIP712Error.unknownType(type)
+        }
+    }
+
+    private func encodeAddress(_ value: Any) throws -> [UInt8] {
+        guard let s = value as? String else { throw EIP712Error.expectedString("address") }
+        let hex = s.hasPrefix("0x") || s.hasPrefix("0X") ? String(s.dropFirst(2)) : s
+        let bytes = [UInt8](hex: hex)
+        guard bytes.count == 20 else { throw EIP712Error.invalidAddress(s) }
+        return Array(repeating: 0, count: 12) + bytes
+    }
+
+    private func encodeBool(_ value: Any) throws -> [UInt8] {
+        let flag: Bool
+        if let b = value as? Bool { flag = b }
+        else if let n = value as? NSNumber { flag = n.boolValue }
+        else if let s = value as? String { flag = (s == "true" || s == "1") }
+        else { throw EIP712Error.expectedBool }
+        return Array(repeating: 0, count: 31) + [flag ? 1 : 0]
+    }
+
+    private func encodeUInt(_ value: Any) throws -> [UInt8] {
+        let v = try parseBigUInt(value)
+        var bytes = Array(v.serialize())
+        if bytes.count > 32 { bytes = Array(bytes.suffix(32)) }
+        return Array(repeating: 0, count: 32 - bytes.count) + bytes
+    }
+
+    private func encodeInt(_ value: Any) throws -> [UInt8] {
+        let v = try parseBigInt(value)
+        let modulus = BigInt(1) << 256
+        let unsigned = v >= 0 ? v : (modulus + v)
+        var bytes = Array(unsigned.magnitude.serialize())
+        if bytes.count > 32 { bytes = Array(bytes.suffix(32)) }
+        return Array(repeating: 0, count: 32 - bytes.count) + bytes
+    }
+
+    private func parseBigUInt(_ value: Any) throws -> BigUInt {
+        if let s = value as? String {
+            let trimmed = s.trimmingCharacters(in: .whitespaces)
+            if trimmed.hasPrefix("0x") || trimmed.hasPrefix("0X") {
+                let hex = String(trimmed.dropFirst(2))
+                if hex.isEmpty { return 0 }
+                guard let parsed = BigUInt(hex, radix: 16) else {
+                    throw EIP712Error.invalidInteger(s)
+                }
+                return parsed
+            }
+            if trimmed.isEmpty { return 0 }
+            guard let parsed = BigUInt(trimmed, radix: 10) else {
+                throw EIP712Error.invalidInteger(s)
+            }
+            return parsed
+        }
+        if let n = value as? NSNumber {
+            guard let parsed = BigUInt(n.stringValue, radix: 10) else {
+                throw EIP712Error.invalidInteger(n.stringValue)
+            }
+            return parsed
+        }
+        throw EIP712Error.invalidInteger(String(describing: value))
+    }
+
+    private func parseBigInt(_ value: Any) throws -> BigInt {
+        if let s = value as? String {
+            let trimmed = s.trimmingCharacters(in: .whitespaces)
+            if trimmed.hasPrefix("-") {
+                let rest = String(trimmed.dropFirst())
+                guard let mag = BigUInt(rest, radix: 10) else {
+                    throw EIP712Error.invalidInteger(s)
+                }
+                return -BigInt(mag)
+            }
+            return BigInt(try parseBigUInt(value))
+        }
+        if let n = value as? NSNumber {
+            let str = n.stringValue
+            if str.hasPrefix("-") {
+                let rest = String(str.dropFirst())
+                guard let mag = BigUInt(rest, radix: 10) else {
+                    throw EIP712Error.invalidInteger(str)
+                }
+                return -BigInt(mag)
+            }
+            guard let mag = BigUInt(str, radix: 10) else {
+                throw EIP712Error.invalidInteger(str)
+            }
+            return BigInt(mag)
+        }
+        throw EIP712Error.invalidInteger(String(describing: value))
+    }
+
+    private func parseBytes(_ value: Any) throws -> [UInt8] {
+        guard let s = value as? String else { throw EIP712Error.expectedString("bytes") }
+        let hex = s.hasPrefix("0x") || s.hasPrefix("0X") ? String(s.dropFirst(2)) : s
+        if hex.isEmpty { return [] }
+        return [UInt8](hex: hex)
+    }
+
+    private static func keccak256(_ bytes: [UInt8]) -> [UInt8] {
+        SHA3(variant: .keccak256).calculate(for: bytes)
+    }
+
+    enum EIP712Error: Error, LocalizedError {
+        case invalidJSON
+        case missing(String)
+        case unknownType(String)
+        case invalidType(String)
+        case expectedObject(String)
+        case expectedArray(String)
+        case expectedString(String)
+        case expectedBool
+        case invalidAddress(String)
+        case invalidInteger(String)
+
+        var errorDescription: String? {
+            switch self {
+            case .invalidJSON: return "Invalid typed-data JSON"
+            case .missing(let f): return "Missing EIP-712 field: \(f)"
+            case .unknownType(let t): return "Unknown EIP-712 type: \(t)"
+            case .invalidType(let t): return "Invalid EIP-712 type: \(t)"
+            case .expectedObject(let t): return "Expected object for type: \(t)"
+            case .expectedArray(let t): return "Expected array for type: \(t)"
+            case .expectedString(let t): return "Expected string value for type: \(t)"
+            case .expectedBool: return "Expected bool value"
+            case .invalidAddress(let a): return "Invalid address: \(a)"
+            case .invalidInteger(let s): return "Invalid integer: \(s)"
+            }
+        }
+    }
+}

--- a/Example/Shared/Signer/EIP712TypedData.swift
+++ b/Example/Shared/Signer/EIP712TypedData.swift
@@ -180,8 +180,10 @@ struct EIP712TypedData {
 
     private func encodeUInt(_ value: Any) throws -> [UInt8] {
         let v = try parseBigUInt(value)
-        var bytes = Array(v.serialize())
-        if bytes.count > 32 { bytes = Array(bytes.suffix(32)) }
+        let bytes = Array(v.serialize())
+        guard bytes.count <= 32 else {
+            throw EIP712Error.integerOutOfRange(String(describing: value))
+        }
         return Array(repeating: 0, count: 32 - bytes.count) + bytes
     }
 
@@ -189,8 +191,10 @@ struct EIP712TypedData {
         let v = try parseBigInt(value)
         let modulus = BigInt(1) << 256
         let unsigned = v >= 0 ? v : (modulus + v)
-        var bytes = Array(unsigned.magnitude.serialize())
-        if bytes.count > 32 { bytes = Array(bytes.suffix(32)) }
+        let bytes = Array(unsigned.magnitude.serialize())
+        guard bytes.count <= 32 else {
+            throw EIP712Error.integerOutOfRange(String(describing: value))
+        }
         return Array(repeating: 0, count: 32 - bytes.count) + bytes
     }
 
@@ -271,6 +275,7 @@ struct EIP712TypedData {
         case expectedBool
         case invalidAddress(String)
         case invalidInteger(String)
+        case integerOutOfRange(String)
 
         var errorDescription: String? {
             switch self {
@@ -284,6 +289,7 @@ struct EIP712TypedData {
             case .expectedBool: return "Expected bool value"
             case .invalidAddress(let a): return "Invalid address: \(a)"
             case .invalidInteger(let s): return "Invalid integer: \(s)"
+            case .integerOutOfRange(let s): return "Integer out of uint256/int256 range: \(s)"
             }
         }
     }

--- a/Example/Shared/Signer/SignTypedDataSigner.swift
+++ b/Example/Shared/Signer/SignTypedDataSigner.swift
@@ -1,70 +1,79 @@
 import Foundation
-import YttriumUtilsWrapper
+import Web3
 
-/// Generic EIP-712 typed data signer using EvmSigningClient from YttriumUtilsWrapper
+/// Generic EIP-712 typed-data signer.
+///
+/// Computes the EIP-712 digest locally via `EIP712TypedData` and signs it with
+/// Web3.swift. Yttrium's `EvmSigningClient.signTypedData` is hardcoded for
+/// ERC-3009 payloads (requires `from/to/value/validAfter/validBefore/nonce` in
+/// the message) and so cannot be used for generic typed data like Permit2.
 final class SignTypedDataSigner {
-    
-    private static let evmSigningClient: EvmSigningClient = {
-        let metadata = PulseMetadata(
-            url: nil,
-            bundleId: Bundle.main.bundleIdentifier ?? "",
-            sdkVersion: "reown-swift-mobile-1.0",
-            sdkPlatform: "mobile"
-        )
-        return EvmSigningClient(projectId: InputConfig.projectId, pulseMetadata: metadata)
-    }()
-    
+
     private let privateKey: String
-    
+
     init(privateKey: String) {
         self.privateKey = privateKey
     }
-    
-    /// Sign EIP-712 typed data from params
+
+    /// Sign EIP-712 typed data from params.
     /// Handles both formats:
-    /// - Direct typed data: {"types": ..., "message": ...}
-    /// - Array format: [address, typedData]
+    /// - Direct typed data: `{"types": ..., "message": ...}`
+    /// - Array format: `[address, typedData]` (standard `eth_signTypedData_v4` params)
+    ///
+    /// Returns a JSON string `{"v": Int, "r": "0x...", "s": "0x..."}` to match
+    /// the contract expected by `ETHSigner.signTypedData`.
     func signTypedDataFromParams(_ params: String) async throws -> String {
         let typedDataJson = try extractTypedData(from: params)
-        return try await Self.evmSigningClient.signTypedData(
-            jsonData: typedDataJson,
-            signer: privateKey
-        )
+        let typedData = try EIP712TypedData.parse(jsonString: typedDataJson)
+        let digest = try typedData.digest()
+
+        let key = try EthereumPrivateKey(hexPrivateKey: privateKey)
+        let (v, r, s) = try key.sign(hash: digest)
+
+        let response: [String: Any] = [
+            "v": Int(v) + 27,
+            "r": "0x" + Self.hexPadded(r),
+            "s": "0x" + Self.hexPadded(s)
+        ]
+        let data = try JSONSerialization.data(withJSONObject: response, options: [])
+        return String(data: data, encoding: .utf8) ?? "{}"
     }
-    
+
     private func extractTypedData(from params: String) throws -> String {
         guard let data = params.data(using: .utf8),
               let json = try? JSONSerialization.jsonObject(with: data) else {
             throw SignTypedDataError.invalidParams
         }
-        
-        // If it's already the typed data object
+
         if json is [String: Any] {
             return params
         }
-        
-        // If it's [address, typedData] array
+
         if let array = json as? [Any], array.count >= 2 {
             let typedData = array[1]
-            
-            // If typedData is already a String (JSON string), return it directly
+
             if let typedDataString = typedData as? String {
                 return typedDataString
             }
-            
-            // If typedData is a dictionary, serialize it
+
             if typedData is [String: Any] {
                 let jsonData = try JSONSerialization.data(withJSONObject: typedData, options: .sortedKeys)
                 return String(data: jsonData, encoding: .utf8) ?? ""
             }
         }
-        
+
         throw SignTypedDataError.invalidParams
     }
-    
+
+    private static func hexPadded(_ bytes: [UInt8]) -> String {
+        let hex = bytes.map { String(format: "%02x", $0) }.joined()
+        if hex.count >= 64 { return String(hex.suffix(64)) }
+        return String(repeating: "0", count: 64 - hex.count) + hex
+    }
+
     enum SignTypedDataError: Error, LocalizedError {
         case invalidParams
-        
+
         var errorDescription: String? {
             "Invalid typed data parameters"
         }

--- a/Example/WalletApp/ApplicationLayer/Configurator/ApplicationConfigurator.swift
+++ b/Example/WalletApp/ApplicationLayer/Configurator/ApplicationConfigurator.swift
@@ -15,8 +15,11 @@ struct ApplicationConfigurator: Configurator {
         let service = WalletGenerationService(accountStorage: app.accountStorage)
 
         #if ENABLE_TEST_MODE
-        // In test mode, use a pre-funded wallet if a private key is provided
-        if let testKey = InputConfig.testWalletPrivateKey, !testKey.isEmpty,
+        // In test mode, use a pre-funded wallet if a private key is provided —
+        // unless the user has manually imported a wallet via Settings, in which case
+        // we must not overwrite their choice on subsequent launches.
+        if !app.accountStorage.userImportedWallet,
+           let testKey = InputConfig.testWalletPrivateKey, !testKey.isEmpty,
            service.importEVMPrivateKey(testKey),
            let account = app.accountStorage.importAccount {
             importAccount = account

--- a/Example/WalletApp/Common/Navigation/NavigationCoordinator.swift
+++ b/Example/WalletApp/Common/Navigation/NavigationCoordinator.swift
@@ -18,21 +18,27 @@ final class NavigationCoordinator: ObservableObject {
     // MARK: - Dependencies
 
     let app: Application
-    var importAccount: ImportAccount?
+    @Published var importAccount: ImportAccount?
 
-    // MARK: - Cached View Models (created once, reused across tab switches)
+    // MARK: - Cached View Models (recreated when the imported wallet changes)
 
-    private(set) lazy var balancesViewModel: BalancesViewModel = {
+    private var _balancesViewModel: BalancesViewModel?
+    var balancesViewModel: BalancesViewModel {
+        if let vm = _balancesViewModel { return vm }
         let vm = BalancesViewModel(app: app, importAccount: importAccount!)
         vm.scanHandler.onScanOverride = { [weak self] in self?.presentScanCamera() }
+        _balancesViewModel = vm
         return vm
-    }()
+    }
 
-    private(set) lazy var walletPresenter: WalletPresenter = {
+    private var _walletPresenter: WalletPresenter?
+    var walletPresenter: WalletPresenter {
+        if let p = _walletPresenter { return p }
         let p = WalletPresenter(interactor: WalletInteractor(), app: app, importAccount: importAccount!)
         p.scanHandler.onScanOverride = { [weak self] in self?.presentScanCamera() }
+        _walletPresenter = p
         return p
-    }()
+    }
 
     private(set) lazy var settingsPresenter: SettingsPresenter = {
         let p = SettingsPresenter(accountStorage: app.accountStorage)
@@ -206,7 +212,12 @@ final class NavigationCoordinator: ObservableObject {
             }
         }
 
-        // Refresh balances
+        // Pick up the newly imported account and rebuild presenters that captured the old one.
+        importAccount = app.accountStorage.importAccount
+        _balancesViewModel = nil
+        _walletPresenter = nil
+
+        // Refresh balances on the fresh view model
         Task { await balancesViewModel.refresh() }
     }
 }

--- a/Example/WalletApp/PresentationLayer/Wallet/AppRootView.swift
+++ b/Example/WalletApp/PresentationLayer/Wallet/AppRootView.swift
@@ -97,6 +97,12 @@ struct AppRootView: View {
             importAccount: coordinator.importAccount!
         )
         presenter.dismissAction = { [weak coordinator] in coordinator?.dismissModal() }
+        presenter.scanNewQRAction = { [weak coordinator] in
+            coordinator?.dismissModal()
+            DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) {
+                coordinator?.presentScanCamera()
+            }
+        }
         return PayContainerView()
             .environmentObject(presenter)
     }

--- a/Example/WalletApp/PresentationLayer/Wallet/Pay/PayConfirmingView.swift
+++ b/Example/WalletApp/PresentationLayer/Wallet/Pay/PayConfirmingView.swift
@@ -14,10 +14,21 @@ struct PayConfirmingView: View {
             Spacer()
                 .frame(height: Spacing._4)
 
-            // Loading text
+            // Loading text — fades + slides when the message changes between steps
+            // (e.g. "Setting up USDC…" → "Finalizing your payment…").
             Text(presenter.loadingMessage)
                 .appFont(.h6)
                 .foregroundColor(AppColors.textPrimary)
+                .multilineTextAlignment(.center)
+                .padding(.horizontal, Spacing._5)
+                .id(presenter.loadingMessage)
+                .transition(
+                    .asymmetric(
+                        insertion: .opacity.combined(with: .move(edge: .bottom)),
+                        removal: .opacity.combined(with: .move(edge: .top))
+                    )
+                )
+                .animation(.easeInOut(duration: 0.25), value: presenter.loadingMessage)
                 .accessibilityIdentifier("pay-loading-message")
 
             Spacer()

--- a/Example/WalletApp/PresentationLayer/Wallet/Pay/PayContainerView.swift
+++ b/Example/WalletApp/PresentationLayer/Wallet/Pay/PayContainerView.swift
@@ -59,12 +59,12 @@ struct PayContainerView: View {
                     .accessibilityElement(children: .contain)
                 }
                 .animation(.easeInOut(duration: 0.25), value: presenter.currentStep)
+                .ignoresSafeArea(edges: .bottom)
             }
         }
         .alert(presenter.errorMessage, isPresented: $presenter.showError) {
             Button("OK", role: .cancel) {}
         }
-        .ignoresSafeArea()
     }
 }
 

--- a/Example/WalletApp/PresentationLayer/Wallet/Pay/PayOptionsView.swift
+++ b/Example/WalletApp/PresentationLayer/Wallet/Pay/PayOptionsView.swift
@@ -27,19 +27,23 @@ struct PayOptionsView: View {
                     .accessibilityIdentifier("pay-merchant-info")
                     .padding(.top, Spacing._5)
 
-                // Payment options list
-                VStack(spacing: Spacing._2) {
-                    ForEach(Array(presenter.paymentOptions.enumerated()), id: \.element.id) { index, option in
-                        let isSelected = presenter.selectedOption?.id == option.id
-                        PaymentOptionCard(
-                            option: option,
-                            isSelected: isSelected,
-                            requiresIC: presenter.anyOptionRequiresIC,
-                            accessibilityId: isSelected ? "pay-option-\(index)-selected" : "pay-option-\(index)",
-                            onSelect: { presenter.selectOption(option) }
-                        )
+                // Payment options list — scrollable so the CTA stays visible
+                // when many options are present.
+                ScrollView(showsIndicators: false) {
+                    VStack(spacing: Spacing._2) {
+                        ForEach(Array(presenter.paymentOptions.enumerated()), id: \.element.id) { index, option in
+                            let isSelected = presenter.selectedOption?.id == option.id
+                            PaymentOptionCard(
+                                option: option,
+                                isSelected: isSelected,
+                                requiresIC: presenter.anyOptionRequiresIC,
+                                accessibilityId: isSelected ? "pay-option-\(index)-selected" : "pay-option-\(index)",
+                                onSelect: { presenter.selectOption(option) }
+                            )
+                        }
                     }
                 }
+                .frame(maxHeight: UIScreen.main.bounds.height * 0.5)
                 .padding(.top, Spacing._7)
 
                 // Primary button

--- a/Example/WalletApp/PresentationLayer/Wallet/Pay/PayPresenter.swift
+++ b/Example/WalletApp/PresentationLayer/Wallet/Pay/PayPresenter.swift
@@ -174,6 +174,7 @@ final class PayPresenter: ObservableObject {
         guard let baseUrlString = collectData?.url,
               !baseUrlString.isEmpty,
               var components = URLComponents(string: baseUrlString),
+              components.scheme?.lowercased() == "https",
               let host = components.host,
               Self.trustedICDomains.contains(host) else {
             print("⚠️ [Pay] Rejected untrusted or invalid IC URL: \(collectData?.url ?? "nil")")

--- a/Example/WalletApp/PresentationLayer/Wallet/Pay/PayPresenter.swift
+++ b/Example/WalletApp/PresentationLayer/Wallet/Pay/PayPresenter.swift
@@ -39,6 +39,17 @@ final class PayPresenter: ObservableObject {
     @Published var selectedOption: PaymentOption?
     @Published var requiredActions: [Action] = []
 
+    // Two-action flow state (Permit2 / approve + sign)
+    @Published var paymentContext: PaymentContext?
+    @Published var isLoadingActions = false
+    @Published var approvalGasEstimate: String?
+    @Published var isEstimatingApprovalGas = false
+    private var actionsRequestSeq: Int = 0
+
+    /// Local expiry safety margin — refuse to broadcast a payment whose
+    /// `expiresAt` is within this window of now.
+    private static let expiryGuardMs: Int64 = 10_000
+
     // Payment result info (from confirmPayment response)
     @Published var paymentResultInfo: ConfirmPaymentResultResponse?
 
@@ -108,6 +119,9 @@ final class PayPresenter: ObservableObject {
                     // Auto-skip to summary for single option with no IC
                     if response.options.count == 1 && response.collectData == nil {
                         self.currentStep = .summary
+                        if let option = response.options.first {
+                            self.loadRequiredActions(for: option, paymentId: response.paymentId)
+                        }
                     } else {
                         self.currentStep = .options
                     }
@@ -121,19 +135,24 @@ final class PayPresenter: ObservableObject {
 
     /// Called from options screen when user taps the primary button
     func continueFromOptions() {
-        guard selectedOption != nil else { return }
+        guard let option = selectedOption,
+              let paymentId = paymentOptionsResponse?.paymentId else { return }
 
         if let collectData = collectData,
            let url = collectData.url, !url.isEmpty {
             currentStep = .webviewDataCollection
         } else {
             currentStep = .summary
+            loadRequiredActions(for: option, paymentId: paymentId)
         }
     }
 
     /// Called when IC WebView completes successfully
     func onICWebViewComplete() {
         currentStep = .summary
+        if let option = selectedOption, let paymentId = paymentOptionsResponse?.paymentId {
+            loadRequiredActions(for: option, paymentId: paymentId)
+        }
     }
 
     /// Called when IC WebView encounters an error
@@ -261,6 +280,63 @@ final class PayPresenter: ObservableObject {
         selectedOption = option
     }
 
+    /// Fetches required actions for the selected option in the background.
+    /// While running, the summary step renders immediately but the Pay button is disabled.
+    /// Uses a request-sequence counter to ignore stale responses from rapid option changes.
+    func loadRequiredActions(for option: PaymentOption, paymentId: String) {
+        actionsRequestSeq += 1
+        let seq = actionsRequestSeq
+        isLoadingActions = true
+        requiredActions = []
+        paymentContext = nil
+        approvalGasEstimate = nil
+        isEstimatingApprovalGas = false
+
+        Task { @MainActor [weak self] in
+            guard let self else { return }
+            do {
+                let actions = try await WalletKit.instance.Pay.getRequiredPaymentActions(
+                    paymentId: paymentId,
+                    optionId: option.id
+                )
+                // Ignore stale response
+                guard seq == self.actionsRequestSeq else { return }
+
+                self.requiredActions = actions
+                let context = PaymentUtil.getPaymentContext(actions: actions)
+                self.paymentContext = context
+                self.isLoadingActions = false
+
+                // Estimate approval fee in background — non-blocking.
+                if let approval = context.approvalAction {
+                    self.isEstimatingApprovalGas = true
+                    Task { @MainActor [weak self] in
+                        guard let self else { return }
+                        let service = PayTransactionService(projectId: InputConfig.projectId)
+                        let estimate = await service.estimateTransactionFee(action: approval)
+                        guard seq == self.actionsRequestSeq else { return }
+                        self.approvalGasEstimate = estimate
+                        self.isEstimatingApprovalGas = false
+                    }
+                }
+            } catch {
+                guard seq == self.actionsRequestSeq else { return }
+                self.isLoadingActions = false
+                self.resultType = Self.detectResultType(from: error)
+                self.currentStep = .result
+            }
+        }
+    }
+
+    /// Returns true when `paymentInfo.expiresAt` is within `expiryGuardMs` of
+    /// the current time (or already past). Matches the Kotlin sample's guard.
+    private func isPaymentExpiredLocally() -> Bool {
+        guard let expiresAtSec = paymentInfo?.expiresAt else { return false }
+        let expiresAtMs = expiresAtSec * 1_000
+        let nowMs = Int64(Date().timeIntervalSince1970 * 1_000)
+        return expiresAtMs <= nowMs + Self.expiryGuardMs
+    }
+
     func confirmPayment() {
         guard let option = selectedOption,
               let paymentId = paymentOptionsResponse?.paymentId else {
@@ -269,31 +345,65 @@ final class PayPresenter: ObservableObject {
             return
         }
 
-        // Switch to confirming state
+        // Local expiry guard — avoid racing an effectively-expired payment
+        // through the RPC flow.
+        if isPaymentExpiredLocally() {
+            resultType = .expired
+            currentStep = .result
+            return
+        }
+
+        // Switch to confirming state. The exact message is set below once we
+        // know whether this is a single- or multi-step flow.
         loadingMessage = "Processing your payment..."
         currentStep = .confirming
 
         Task { @MainActor [weak self] in
             guard let self else { return }
             do {
-                // 1. Get required actions for the selected option
-                let actions = try await WalletKit.instance.Pay.getRequiredPaymentActions(
-                    paymentId: paymentId,
-                    optionId: option.id
-                )
-                self.requiredActions = actions
-
-                // 2. Sign all wallet RPC actions
-                var signatures: [String] = []
-                let ethSigner = ETHSigner(importAccount: importAccount)
-
-                for action in actions {
-                    let rpcAction = action.walletRpc
-                    let signature = try await ethSigner.signTypedData(AnyCodable(rpcAction.params))
-                    signatures.append(signature)
+                // Ensure we have the required actions (may still be in flight if user tapped fast).
+                let actions: [Action]
+                if !self.requiredActions.isEmpty {
+                    actions = self.requiredActions
+                } else {
+                    actions = try await WalletKit.instance.Pay.getRequiredPaymentActions(
+                        paymentId: paymentId,
+                        optionId: option.id
+                    )
+                    self.requiredActions = actions
+                    self.paymentContext = PaymentUtil.getPaymentContext(actions: actions)
                 }
 
-                // 3. Confirm payment with signatures
+                let tokenSymbol = option.amount.display.assetSymbol
+                let txService = PayTransactionService(projectId: InputConfig.projectId)
+                let ethSigner = ETHSigner(importAccount: importAccount)
+                var signatures: [String] = []
+                let isMultiStep = self.paymentContext?.requiresApproval == true
+
+                for action in actions {
+                    switch action.walletRpc.method {
+                    case "eth_sendTransaction":
+                        self.loadingMessage = "Setting up \(tokenSymbol) for the first time…"
+                        _ = try await txService.sendTransactionAndWait(
+                            action: action,
+                            importAccount: self.importAccount
+                        )
+                    case "eth_signTypedData", "eth_signTypedData_v3", "eth_signTypedData_v4":
+                        self.loadingMessage = isMultiStep
+                            ? "Finalizing your payment…"
+                            : "Processing your payment..."
+                        let signature = try await ethSigner.signTypedData(
+                            AnyCodable(action.walletRpc.params)
+                        )
+                        signatures.append(signature)
+                    default:
+                        throw PayPresenterError.unsupportedWalletRpcMethod(action.walletRpc.method)
+                    }
+                }
+
+                self.loadingMessage = isMultiStep
+                    ? "Finalizing your payment…"
+                    : "Processing your payment..."
                 let result = try await WalletKit.instance.Pay.confirmPayment(
                     paymentId: paymentId,
                     optionId: option.id,
@@ -325,6 +435,17 @@ final class PayPresenter: ObservableObject {
             } catch {
                 self.resultType = Self.detectResultType(from: error)
                 self.currentStep = .result
+            }
+        }
+    }
+
+    enum PayPresenterError: Error, LocalizedError {
+        case unsupportedWalletRpcMethod(String)
+
+        var errorDescription: String? {
+            switch self {
+            case .unsupportedWalletRpcMethod(let m):
+                return "Unsupported wallet RPC method: \(m)"
             }
         }
     }

--- a/Example/WalletApp/PresentationLayer/Wallet/Pay/PayPresenter.swift
+++ b/Example/WalletApp/PresentationLayer/Wallet/Pay/PayPresenter.swift
@@ -15,6 +15,7 @@ enum PayFlowStep: Int, CaseIterable {
 
 final class PayPresenter: ObservableObject {
     var dismissAction: (() -> Void)?
+    var scanNewQRAction: (() -> Void)?
     private let importAccount: ImportAccount
     private var disposeBag = Set<AnyCancellable>()
 
@@ -452,6 +453,15 @@ final class PayPresenter: ObservableObject {
 
     func dismiss() {
         dismissAction?()
+    }
+
+    func primaryResultAction() {
+        switch resultType {
+        case .expired:
+            scanNewQRAction?()
+        case .success, .insufficientFunds, .cancelled, .notFound, .generic:
+            dismiss()
+        }
     }
 
     // MARK: - Error Detection

--- a/Example/WalletApp/PresentationLayer/Wallet/Pay/PayRPCClient.swift
+++ b/Example/WalletApp/PresentationLayer/Wallet/Pay/PayRPCClient.swift
@@ -1,0 +1,170 @@
+import Foundation
+
+/// Minimal JSON-RPC client against WalletConnect's blockchain RPC.
+/// Endpoint: https://rpc.walletconnect.org/v1/?chainId=<caip2>&projectId=<pid>
+struct PayRPCClient {
+    let chainId: String
+    let projectId: String
+    private let session: URLSession
+
+    init(chainId: String, projectId: String, session: URLSession = .shared) {
+        self.chainId = chainId
+        self.projectId = projectId
+        self.session = session
+    }
+
+    // MARK: - Typed convenience methods
+
+    func gasPrice() async throws -> String {
+        try await call(method: "eth_gasPrice", params: [])
+    }
+
+    func maxPriorityFeePerGas() async throws -> String {
+        try await call(method: "eth_maxPriorityFeePerGas", params: [])
+    }
+
+    func getLatestBlock() async throws -> RPCBlock {
+        try await call(method: "eth_getBlockByNumber", params: [.string("latest"), .bool(false)])
+    }
+
+    func estimateGas(_ tx: RPCTxRequest) async throws -> String {
+        try await call(method: "eth_estimateGas", params: [.object(tx.toParams())])
+    }
+
+    func getTransactionCount(address: String, block: String = "pending") async throws -> String {
+        try await call(method: "eth_getTransactionCount", params: [.string(address), .string(block)])
+    }
+
+    func sendRawTransaction(_ rawHex: String) async throws -> String {
+        try await call(method: "eth_sendRawTransaction", params: [.string(rawHex)])
+    }
+
+    func getTransactionReceipt(hash: String) async throws -> RPCTransactionReceipt? {
+        try await callOptional(method: "eth_getTransactionReceipt", params: [.string(hash)])
+    }
+
+    // MARK: - Generic RPC
+
+    func call<T: Decodable>(method: String, params: [RPCParam]) async throws -> T {
+        let data = try await send(method: method, params: params)
+        let response = try JSONDecoder().decode(RPCResponse<T>.self, from: data)
+        if let error = response.error {
+            throw PayRPCError.rpc(code: error.code, message: error.message)
+        }
+        guard let result = response.result else {
+            throw PayRPCError.emptyResult
+        }
+        return result
+    }
+
+    func callOptional<T: Decodable>(method: String, params: [RPCParam]) async throws -> T? {
+        let data = try await send(method: method, params: params)
+        let response = try JSONDecoder().decode(RPCResponse<T>.self, from: data)
+        if let error = response.error {
+            throw PayRPCError.rpc(code: error.code, message: error.message)
+        }
+        return response.result
+    }
+
+    private func send(method: String, params: [RPCParam]) async throws -> Data {
+        guard var components = URLComponents(string: "https://rpc.walletconnect.org/v1/") else {
+            throw PayRPCError.invalidURL
+        }
+        components.queryItems = [
+            URLQueryItem(name: "chainId", value: chainId),
+            URLQueryItem(name: "projectId", value: projectId)
+        ]
+        guard let url = components.url else { throw PayRPCError.invalidURL }
+
+        var request = URLRequest(url: url, timeoutInterval: 15)
+        request.httpMethod = "POST"
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+
+        let body = RPCRequest(method: method, params: params)
+        request.httpBody = try JSONEncoder().encode(body)
+
+        let (data, response) = try await session.data(for: request)
+        if let http = response as? HTTPURLResponse, !(200..<300).contains(http.statusCode) {
+            throw PayRPCError.httpStatus(http.statusCode)
+        }
+        return data
+    }
+}
+
+// MARK: - Request/response types
+
+enum PayRPCError: Error, LocalizedError {
+    case invalidURL
+    case httpStatus(Int)
+    case rpc(code: Int, message: String)
+    case emptyResult
+
+    var errorDescription: String? {
+        switch self {
+        case .invalidURL: return "Invalid RPC URL"
+        case .httpStatus(let code): return "RPC HTTP \(code)"
+        case .rpc(let code, let message): return "RPC error \(code): \(message)"
+        case .emptyResult: return "RPC result was empty"
+        }
+    }
+}
+
+/// A JSON-RPC param that can be a string, bool, number, or a nested object (used for tx request).
+enum RPCParam: Encodable {
+    case string(String)
+    case bool(Bool)
+    case object([String: String])
+
+    func encode(to encoder: Encoder) throws {
+        var container = encoder.singleValueContainer()
+        switch self {
+        case .string(let v): try container.encode(v)
+        case .bool(let v): try container.encode(v)
+        case .object(let v): try container.encode(v)
+        }
+    }
+}
+
+private struct RPCRequest: Encodable {
+    let jsonrpc = "2.0"
+    let id = 1
+    let method: String
+    let params: [RPCParam]
+}
+
+struct RPCResponse<T: Decodable>: Decodable {
+    let result: T?
+    let error: RPCErrorBody?
+}
+
+struct RPCErrorBody: Decodable {
+    let code: Int
+    let message: String
+}
+
+struct RPCBlock: Decodable {
+    let baseFeePerGas: String?
+    let number: String?
+}
+
+struct RPCTransactionReceipt: Decodable {
+    let status: String?
+    let transactionHash: String?
+    let blockNumber: String?
+}
+
+/// Transaction shape passed to `eth_estimateGas` — all fields hex-encoded.
+struct RPCTxRequest {
+    var from: String
+    var to: String?
+    var data: String?
+    var value: String?
+
+    func toParams() -> [String: String] {
+        var dict: [String: String] = ["from": from]
+        if let to { dict["to"] = to }
+        if let data { dict["data"] = data }
+        if let value { dict["value"] = value }
+        return dict
+    }
+}

--- a/Example/WalletApp/PresentationLayer/Wallet/Pay/PayResultView.swift
+++ b/Example/WalletApp/PresentationLayer/Wallet/Pay/PayResultView.swift
@@ -69,7 +69,7 @@ struct PayResultView: View {
             PayPrimaryButton(
                 title: buttonTitle,
                 accessibilityId: buttonAccessibilityId,
-                action: { presenter.dismiss() }
+                action: { presenter.primaryResultAction() }
             )
 
             Spacer()

--- a/Example/WalletApp/PresentationLayer/Wallet/Pay/PaySummaryView.swift
+++ b/Example/WalletApp/PresentationLayer/Wallet/Pay/PaySummaryView.swift
@@ -4,6 +4,16 @@ import WalletConnectPay
 struct PaySummaryView: View {
     @EnvironmentObject var presenter: PayPresenter
 
+    /// Three-state label for the approval fee row:
+    ///  - "Loading…" while the gas estimate RPC is in flight,
+    ///  - the formatted estimate once it resolves,
+    ///  - "Network fee set by wallet" if estimation failed.
+    private var approvalFeeText: String {
+        if presenter.isEstimatingApprovalGas { return "Loading…" }
+        if let estimate = presenter.approvalGasEstimate { return estimate }
+        return "Network fee set by wallet"
+    }
+
     var body: some View {
         PayModalContainer {
             // Header: back (left) + X close (right)
@@ -52,12 +62,35 @@ struct PaySummaryView: View {
                     .padding(.top, Spacing._6)
                 }
 
+                // One-time approval fee row — shown only when the selected option
+                // requires an on-chain approve before the permit signature.
+                if presenter.paymentContext?.requiresApproval == true {
+                    HStack {
+                        Text("One-time fee")
+                            .appFont(.lg)
+                            .foregroundColor(AppColors.textTertiary)
+
+                        Spacer()
+
+                        Text(approvalFeeText)
+                            .appFont(.lg)
+                            .foregroundColor(AppColors.textPrimary)
+                    }
+                    .padding(.horizontal, Spacing._5)
+                    .frame(height: 68)
+                    .background(AppColors.foregroundPrimary)
+                    .cornerRadius(AppRadius._4)
+                    .accessibilityIdentifier("pay-review-one-time-fee")
+                    .padding(.top, Spacing._3)
+                }
+
                 Spacer()
                     .frame(height: Spacing._5)
 
-                // Pay button
+                // Pay button — disabled while actions are loading.
                 PayPrimaryButton(
                     title: "Pay \(info.formattedAmount)",
+                    isEnabled: !presenter.isLoadingActions,
                     accessibilityId: "pay-button-pay",
                     action: { presenter.confirmPayment() }
                 )

--- a/Example/WalletApp/PresentationLayer/Wallet/Pay/PayTransactionService.swift
+++ b/Example/WalletApp/PresentationLayer/Wallet/Pay/PayTransactionService.swift
@@ -113,6 +113,11 @@ struct PayTransactionService {
 
         let privateKey = try EthereumPrivateKey(hexPrivateKey: importAccount.privateKey)
 
+        let signerAddress = privateKey.address.hex(eip55: false)
+        guard payload.from.lowercased() == signerAddress.lowercased() else {
+            throw PayTxError.fromAddressMismatch(payload: payload.from, signer: signerAddress)
+        }
+
         let estimateRequest = RPCTxRequest(
             from: payload.from,
             to: payload.to,
@@ -285,6 +290,7 @@ enum PayTxError: Error, LocalizedError {
     case timeout(String)
     case txReverted(hash: String)
     case receiptTimeout(hash: String)
+    case fromAddressMismatch(payload: String, signer: String)
 
     var errorDescription: String? {
         switch self {
@@ -293,6 +299,8 @@ enum PayTxError: Error, LocalizedError {
         case .timeout(let m): return "Timed out: \(m)"
         case .txReverted(let h): return "Transaction reverted: \(h)"
         case .receiptTimeout(let h): return "Timed out waiting for receipt \(h)"
+        case .fromAddressMismatch(let p, let s):
+            return "Payload sender \(p) does not match signer \(s)"
         }
     }
 }

--- a/Example/WalletApp/PresentationLayer/Wallet/Pay/PayTransactionService.swift
+++ b/Example/WalletApp/PresentationLayer/Wallet/Pay/PayTransactionService.swift
@@ -1,0 +1,298 @@
+import Foundation
+import BigInt
+import Web3
+import WalletConnectPay
+
+/// Mirrors `src/utils/PaymentTransactionUtil.ts` from RN PR #472.
+/// Responsible for:
+/// - Estimating the native-token cost of an approval transaction for summary UI.
+/// - Signing and submitting an `eth_sendTransaction` action with fresh EIP-1559 fees.
+/// - Polling `eth_getTransactionReceipt` until the tx lands (or times out).
+struct PayTransactionService {
+    private let projectId: String
+
+    init(projectId: String) {
+        self.projectId = projectId
+    }
+
+    // MARK: - Constants (mirror RN)
+
+    private static let gasEstimationRpcTimeoutMs: UInt64 = 15_000
+    private static let receiptPollIntervalMs: UInt64 = 1_500
+    private static let receiptPollTimeoutMs: UInt64 = 120_000
+
+    /// 20% gas-limit buffer applied to `eth_estimateGas` results to avoid
+    /// `intrinsic gas too low` reverts on approval txs.
+    private static let gasBufferNumerator: BigUInt = 120
+    private static let gasBufferDenominator: BigUInt = 100
+
+    /// Polygon mainnet + Amoy testnets — floor priority fee of 30 gwei.
+    private static let priorityFeeFloorByChain: [String: BigUInt] = [
+        "eip155:137":   BigUInt(30_000_000_000),
+        "eip155:80001": BigUInt(30_000_000_000),
+        "eip155:80002": BigUInt(30_000_000_000)
+    ]
+
+    /// Native token symbol by CAIP-2 chain id. Polygon intentionally uses POL
+    /// (post-migration) rather than MATIC.
+    private static let nativeSymbolByChainId: [String: String] = [
+        "eip155:1":     "ETH",
+        "eip155:10":    "ETH",
+        "eip155:137":   "POL",
+        "eip155:80001": "POL",
+        "eip155:80002": "POL",
+        "eip155:8453":  "ETH",
+        "eip155:42161": "ETH",
+        "eip155:11155111": "ETH",
+        "eip155:84532":  "ETH"
+    ]
+
+    // MARK: - Public API
+
+    /// Returns a short human-readable fee preview string, e.g. "~0.0034 POL".
+    /// Returns `nil` if estimation fails for any reason.
+    func estimateTransactionFee(action: Action) async -> String? {
+        guard let payload = Self.decodePayload(from: action.walletRpc.params) else { return nil }
+
+        let chainId = action.walletRpc.chainId
+        let client = PayRPCClient(chainId: chainId, projectId: projectId)
+        let symbol = Self.nativeSymbolByChainId[chainId] ?? "ETH"
+
+        let request = RPCTxRequest(
+            from: payload.from,
+            to: payload.to,
+            data: payload.data,
+            value: payload.value
+        )
+
+        do {
+            let gasLimitHex: String = try await Self.withTimeout(message: "eth_estimateGas") {
+                try await client.estimateGas(request)
+            }
+            let latestBlock: RPCBlock = try await Self.withTimeout(message: "eth_getBlockByNumber") {
+                try await client.getLatestBlock()
+            }
+            let priorityHex: String? = try? await Self.withTimeout(message: "eth_maxPriorityFeePerGas") {
+                try await client.maxPriorityFeePerGas()
+            }
+            let gasPriceHex: String? = try? await Self.withTimeout(message: "eth_gasPrice") {
+                try await client.gasPrice()
+            }
+
+            let rawGasLimit = Self.parseHex(gasLimitHex) ?? 0
+            let gasLimit = Self.applyGasBuffer(rawGasLimit)
+            let priority = Self.parseHex(priorityHex ?? "")
+            let legacyGasPrice = Self.parseHex(gasPriceHex ?? "")
+
+            let fees = Self.computeFees(
+                chainId: chainId,
+                baseFeeHex: latestBlock.baseFeePerGas,
+                priorityFee: priority,
+                legacyGasPrice: legacyGasPrice
+            )
+            let totalWei = gasLimit * fees.maxFee
+            return Self.formatFee(weiTotal: totalWei, symbol: symbol)
+        } catch {
+            print("💳 [PayTx] estimateTransactionFee error: \(error)")
+            return nil
+        }
+    }
+
+    /// Signs and submits a fresh EIP-1559 transaction for the given action, then
+    /// waits for the receipt. Returns the tx hash on success.
+    @discardableResult
+    func sendTransactionAndWait(action: Action, importAccount: ImportAccount) async throws -> String {
+        guard let payload = Self.decodePayload(from: action.walletRpc.params) else {
+            throw PayTxError.invalidPayload
+        }
+        let chainId = action.walletRpc.chainId
+        guard let numericChainId = Self.numericChainId(from: chainId) else {
+            throw PayTxError.unsupportedChainId(chainId)
+        }
+        let client = PayRPCClient(chainId: chainId, projectId: projectId)
+
+        let privateKey = try EthereumPrivateKey(hexPrivateKey: importAccount.privateKey)
+
+        let estimateRequest = RPCTxRequest(
+            from: payload.from,
+            to: payload.to,
+            data: payload.data,
+            value: payload.value
+        )
+
+        let latestBlock = try await client.getLatestBlock()
+        let priorityHex: String? = try? await client.maxPriorityFeePerGas()
+        let gasPriceHex: String? = try? await client.gasPrice()
+        let nonceHex = try await client.getTransactionCount(address: payload.from, block: "pending")
+        let gasLimitHex = try await client.estimateGas(estimateRequest)
+
+        let priority = Self.parseHex(priorityHex ?? "")
+        let legacyGasPrice = Self.parseHex(gasPriceHex ?? "")
+        let nonce = Self.parseHex(nonceHex) ?? 0
+        let gasLimit = Self.applyGasBuffer(Self.parseHex(gasLimitHex) ?? 0)
+
+        let fees = Self.computeFees(
+            chainId: chainId,
+            baseFeeHex: latestBlock.baseFeePerGas,
+            priorityFee: priority,
+            legacyGasPrice: legacyGasPrice
+        )
+
+        let txValue = Self.parseHex(payload.value ?? "0x0") ?? 0
+        let dataBytes: Bytes
+        if let dataHex = payload.data {
+            let stripped = dataHex.hasPrefix("0x") ? String(dataHex.dropFirst(2)) : dataHex
+            dataBytes = Bytes(hex: stripped)
+        } else {
+            dataBytes = []
+        }
+        let toAddress = try EthereumAddress(hex: payload.to, eip55: false)
+
+        let tx = EthereumTransaction(
+            nonce: EthereumQuantity(quantity: nonce),
+            gasPrice: nil,
+            maxFeePerGas: EthereumQuantity(quantity: fees.maxFee),
+            maxPriorityFeePerGas: EthereumQuantity(quantity: fees.priority),
+            gasLimit: EthereumQuantity(quantity: gasLimit),
+            from: privateKey.address,
+            to: toAddress,
+            value: EthereumQuantity(quantity: txValue),
+            data: EthereumData(dataBytes),
+            accessList: [:],
+            transactionType: .eip1559
+        )
+
+        let signed = try tx.sign(with: privateKey, chainId: EthereumQuantity(quantity: BigUInt(numericChainId)))
+        let rawHex = try signed.rawTransaction().hex()
+
+        let hash = try await client.sendRawTransaction(rawHex)
+        try await waitForReceipt(hash: hash, client: client)
+        return hash
+    }
+
+    // MARK: - Helpers
+
+    private func waitForReceipt(hash: String, client: PayRPCClient) async throws {
+        let deadline = Date().addingTimeInterval(Double(Self.receiptPollTimeoutMs) / 1_000)
+        while Date() < deadline {
+            let maybeReceipt = try? await client.getTransactionReceipt(hash: hash)
+            if let receipt = maybeReceipt ?? nil {
+                let statusOk = (Self.parseHex(receipt.status ?? "0x1") ?? 1) == 1
+                if !statusOk {
+                    throw PayTxError.txReverted(hash: hash)
+                }
+                return
+            }
+            try await Task.sleep(nanoseconds: Self.receiptPollIntervalMs * 1_000_000)
+        }
+        throw PayTxError.receiptTimeout(hash: hash)
+    }
+
+    /// EIP-1559 fee calculation mirroring `buildFreshTxRequest` in the RN util.
+    private static func computeFees(
+        chainId: String,
+        baseFeeHex: String?,
+        priorityFee: BigUInt?,
+        legacyGasPrice: BigUInt?
+    ) -> (maxFee: BigUInt, priority: BigUInt) {
+        let oneGwei = BigUInt(1_000_000_000)
+        var priority = priorityFee ?? oneGwei
+        if let floor = priorityFeeFloorByChain[chainId] {
+            priority = max(priority, floor)
+        }
+
+        let baseFee = parseHex(baseFeeHex ?? "") ?? 0
+        var maxFee = baseFee * 2 + priority
+        if let legacyGasPrice { maxFee = max(maxFee, legacyGasPrice) }
+        maxFee = max(maxFee, priority)
+        return (maxFee, priority)
+    }
+
+    private static func formatFee(weiTotal: BigUInt, symbol: String) -> String {
+        let divisor = BigUInt(10).power(18)
+        let wholePart = weiTotal / divisor
+        let fractionalPart = weiTotal % divisor
+        let native = Double(wholePart) + Double(fractionalPart) / pow(10.0, 18)
+        let formatter = NumberFormatter()
+        formatter.numberStyle = .decimal
+        formatter.locale = Locale(identifier: "en_US_POSIX")
+        let digits = native >= 0.01 ? 4 : 6
+        formatter.minimumFractionDigits = digits
+        formatter.maximumFractionDigits = digits
+        let formatted = formatter.string(from: NSNumber(value: native)) ?? String(format: "%.6f", native)
+        return "~\(formatted) \(symbol)"
+    }
+
+    private static func applyGasBuffer(_ gas: BigUInt) -> BigUInt {
+        (gas * gasBufferNumerator) / gasBufferDenominator
+    }
+
+    private static func parseHex(_ hex: String) -> BigUInt? {
+        guard !hex.isEmpty else { return nil }
+        let stripped = hex.hasPrefix("0x") ? String(hex.dropFirst(2)) : hex
+        guard !stripped.isEmpty else { return BigUInt(0) }
+        return BigUInt(stripped, radix: 16)
+    }
+
+    private static func numericChainId(from caip2: String) -> Int? {
+        let parts = caip2.split(separator: ":")
+        guard parts.count == 2, parts[0] == "eip155" else { return nil }
+        return Int(parts[1])
+    }
+
+    /// Wraps an async throwing operation with a timeout — throws `PayTxError.timeout` on expiry.
+    static func withTimeout<T>(
+        timeoutMs: UInt64 = gasEstimationRpcTimeoutMs,
+        message: String,
+        _ operation: @escaping @Sendable () async throws -> T
+    ) async throws -> T where T: Sendable {
+        try await withThrowingTaskGroup(of: T.self) { group in
+            group.addTask { try await operation() }
+            group.addTask {
+                try await Task.sleep(nanoseconds: timeoutMs * 1_000_000)
+                throw PayTxError.timeout(message)
+            }
+            let result = try await group.next()
+            group.cancelAll()
+            guard let result else { throw PayTxError.timeout(message) }
+            return result
+        }
+    }
+
+    // MARK: - Payload decoding
+
+    private struct TxPayload: Decodable {
+        let from: String
+        let to: String
+        let data: String?
+        let value: String?
+        let gas: String?
+        let gasLimit: String?
+    }
+
+    private static func decodePayload(from paramsJson: String) -> TxPayload? {
+        guard let data = paramsJson.data(using: .utf8) else { return nil }
+        if let array = try? JSONDecoder().decode([TxPayload].self, from: data), let first = array.first {
+            return first
+        }
+        return try? JSONDecoder().decode(TxPayload.self, from: data)
+    }
+}
+
+enum PayTxError: Error, LocalizedError {
+    case invalidPayload
+    case unsupportedChainId(String)
+    case timeout(String)
+    case txReverted(hash: String)
+    case receiptTimeout(hash: String)
+
+    var errorDescription: String? {
+        switch self {
+        case .invalidPayload: return "Invalid eth_sendTransaction payload"
+        case .unsupportedChainId(let id): return "Unsupported chain id: \(id)"
+        case .timeout(let m): return "Timed out: \(m)"
+        case .txReverted(let h): return "Transaction reverted: \(h)"
+        case .receiptTimeout(let h): return "Timed out waiting for receipt \(h)"
+        }
+    }
+}

--- a/Example/WalletApp/PresentationLayer/Wallet/Pay/PaymentUtil.swift
+++ b/Example/WalletApp/PresentationLayer/Wallet/Pay/PaymentUtil.swift
@@ -1,0 +1,19 @@
+import Foundation
+import WalletConnectPay
+
+struct PaymentContext {
+    let approvalAction: Action?
+
+    var requiresApproval: Bool { approvalAction != nil }
+}
+
+enum PaymentUtil {
+    /// Returns the payment context for a list of wallet RPC actions.
+    /// The approval action is the first `eth_sendTransaction` in the list — mirrors
+    /// `src/utils/PaymentUtil.ts` from `reown-com/react-native-examples#472`.
+    static func getPaymentContext(actions: [Action]?) -> PaymentContext {
+        guard let actions else { return PaymentContext(approvalAction: nil) }
+        let approval = actions.first { $0.walletRpc.method == "eth_sendTransaction" }
+        return PaymentContext(approvalAction: approval)
+    }
+}

--- a/Example/WalletApp/PresentationLayer/Wallet/Settings/ImportWallet/ImportWalletPresenter.swift
+++ b/Example/WalletApp/PresentationLayer/Wallet/Settings/ImportWallet/ImportWalletPresenter.swift
@@ -32,9 +32,11 @@ final class ImportWalletPresenter: ObservableObject {
     @Published var showSuccess: Bool = false
 
     private let walletService: WalletGenerationService
+    private let accountStorage: AccountStorage
 
-    init(walletService: WalletGenerationService) {
+    init(walletService: WalletGenerationService, accountStorage: AccountStorage) {
         self.walletService = walletService
+        self.accountStorage = accountStorage
     }
 
     var canImport: Bool {
@@ -68,6 +70,7 @@ final class ImportWalletPresenter: ObservableObject {
         isImporting = false
 
         if success {
+            accountStorage.userImportedWallet = true
             input = ""
             showSuccess = true
             NotificationCenter.default.post(name: .walletImported, object: nil)

--- a/Example/WalletApp/PresentationLayer/Wallet/Settings/ImportWallet/ImportWalletView.swift
+++ b/Example/WalletApp/PresentationLayer/Wallet/Settings/ImportWallet/ImportWalletView.swift
@@ -58,6 +58,8 @@ struct ImportWalletView: View {
                 .scrollContentBackground(.hidden)
                 .frame(minHeight: 100)
                 .padding(.horizontal, Spacing._05)
+                .autocorrectionDisabled(true)
+                .textInputAutocapitalization(.never)
         }
         .background(AppColors.foregroundPrimary)
         .cornerRadius(AppRadius._3)

--- a/Example/WalletApp/PresentationLayer/Wallet/Settings/SettingsPresenter.swift
+++ b/Example/WalletApp/PresentationLayer/Wallet/Settings/SettingsPresenter.swift
@@ -39,7 +39,7 @@ final class SettingsPresenter: ObservableObject {
 
     func makeImportWalletPresenter() -> ImportWalletPresenter {
         let service = WalletGenerationService(accountStorage: accountStorage)
-        return ImportWalletPresenter(walletService: service)
+        return ImportWalletPresenter(walletService: service, accountStorage: accountStorage)
     }
 
     private func presentScanCamera() {


### PR DESCRIPTION
## Summary

Mirrors [react-native-examples#472](https://github.com/reown-com/react-native-examples/pull/472) on Swift. Permit2 payments deliver two wallet-RPC actions — an on-chain ERC-20 `approve` followed by an EIP-712 typed-data signature — which the previous single-step signer couldn't execute.

- Add `PayRPCClient` + `PayTransactionService` so the wallet submits the approve tx and waits for a receipt before signing the permit.
- Ship a local `EIP712TypedData` hasher; Yttrium's `signTypedData` is hardcoded to ERC-3009 (requires `from/to/value/validAfter/validBefore/nonce`) and fails on Permit2 with `missing 'from' in message`.
- Show a "One-time fee" estimate on the review screen and a 10 s local expiry guard before submitting the approval.
- `PayOptionsView`: scrollable list + safe-area handling so long option lists don't hide the Pay CTA or push the header under the notch.
- Auto-fade loader text between approval and signature steps.
- ImportWallet input disables autocorrect/autocapitalize; cached presenters and `TEST_WALLET_PRIVATE_KEY` no longer clobber a manually-imported wallet on next launch.

## Test plan

- [x] `xcodebuild -project Example/ExampleApp.xcodeproj -scheme WalletApp -destination 'platform=iOS Simulator,name=iPhone 16' build`
- [x] Fresh Polygon USDC payment → review shows "One-time fee: ~X POL" → approve tx submits → Permit2 signature → success.
- [x] Second payment on the same token → no approval row → single signature → success.
- [x] Merchant with many options → list scrolls internally, Pay CTA stays visible, header stays below the notch.
- [x] Rapidly switch between options → only the last selection's gas estimate appears on the review screen.
- [x] Import a seed via Settings → first character is lowercase, no autocorrect → relaunch the app → the imported wallet is preserved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)