### PR TITLE
fix(pay): include broadcast tx hash in WCPay signatures

### DIFF
--- a/Example/WalletApp/PresentationLayer/Wallet/Pay/PayPresenter.swift
+++ b/Example/WalletApp/PresentationLayer/Wallet/Pay/PayPresenter.swift
@@ -386,10 +386,11 @@ final class PayPresenter: ObservableObject {
                     switch action.walletRpc.method {
                     case "eth_sendTransaction":
                         self.loadingMessage = "Setting up \(tokenSymbol) for the first time…"
-                        _ = try await txService.sendTransactionAndWait(
+                        let txHash = try await txService.sendTransactionAndWait(
                             action: action,
                             importAccount: self.importAccount
                         )
+                        signatures.append(txHash)
                     case "eth_signTypedData", "eth_signTypedData_v3", "eth_signTypedData_v4":
                         self.loadingMessage = isMultiStep
                             ? "Finalizing your payment…"


### PR DESCRIPTION
## Summary

- Native ETH payments via WCPay (e.g., ETH on Base) only produce a single `eth_sendTransaction` action. The wallet broadcasts that tx via `PayTransactionService.sendTransactionAndWait`, but the returned tx hash was discarded with `_ =`, so `confirmPayment` was called with an empty `signatures` list.
- The yttrium-wcpay backend rejects this with `400: Validation error: Next result not present` because its result chain expects one entry per required action.
- Fix: capture the tx hash from `sendTransactionAndWait` and append it to `signatures`, keeping `signatures.count == actions.count` and preserving order.
- Same fix applied in the Kotlin SDK: reown-com/reown-kotlin#380.

## Action → signature mapping after this change

```mermaid
flowchart LR
    A[actions] --> B{action.walletRpc.method}
    B -->|eth_sendTransaction| C[PayTransactionService.sendTransactionAndWait]
    C --> D[signatures.append&#40;txHash&#41;]
    B -->|eth_signTypedData_*| E[ETHSigner.signTypedData]
    E --> F[signatures.append&#40;signature&#41;]
    D --> G[Pay.confirmPayment&#40;signatures&#41;]
    F --> G
```

## Test plan

- [ ] Native ETH payment on Base completes successfully (was failing with `400: Validation error: Next result not present`)
- [ ] Permit2 USDC payment on Base/OP/Polygon/Mainnet (with first-time approval `eth_sendTransaction` + `eth_signTypedData_v4`) still completes — verify both entries land in `signatures` in order
- [ ] USDC payment with no approval required still completes
- [ ] Console shows the broadcast tx hash before `Payment confirmed:` is printed

🤖 Generated with [Claude Code](https://claude.com/claude-code)