### PR TITLE
ci: pin maestro actions to 52e0ab7

### DIFF
--- a/.github/workflows/ci_e2e_pay_tests.yml
+++ b/.github/workflows/ci_e2e_pay_tests.yml
@@ -59,10 +59,10 @@ jobs:
             | xcbeautify
 
       - name: Copy shared Pay test flows
-        uses: WalletConnect/actions/maestro/pay-tests@afc741fbe638ca13cfc10de2ed59b064c2b59436 # main
+        uses: WalletConnect/actions/maestro/pay-tests@52e0ab7755ca993bd829062278654ed12b2d471d # main
 
       - name: Install Maestro
-        uses: WalletConnect/actions/maestro/setup@afc741fbe638ca13cfc10de2ed59b064c2b59436 # main
+        uses: WalletConnect/actions/maestro/setup@52e0ab7755ca993bd829062278654ed12b2d471d # main
         with:
           version: '2.4.0'
 


### PR DESCRIPTION
Pins the WalletConnect/actions Maestro actions used in the E2E Pay tests workflow to SHA `52e0ab7755ca993bd829062278654ed12b2d471d`.

Updates both pins in `.github/workflows/ci_e2e_pay_tests.yml`:
- `maestro/pay-tests`
- `maestro/setup`

🤖 Generated with [Claude Code](https://claude.com/claude-code)