### PR TITLE
chore(deps): pin SDK dependencies to strict (exact) versions

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -8,9 +8,9 @@ let yttriumDebug = false
 
 // Define dependencies array
 var dependencies: [Package.Dependency] = [
-    .package(url: "https://github.com/apple/swift-docc-plugin", from: "1.3.0"),
-    .package(url: "https://github.com/WalletConnect/QRCode", from: "14.3.1"),
-    .package(name: "CoinbaseWalletSDK", url: "https://github.com/MobileWalletProtocol/wallet-mobile-sdk", .upToNextMinor(from: "1.1.0")),
+    .package(url: "https://github.com/apple/swift-docc-plugin", .exact("1.4.5")),
+    .package(url: "https://github.com/WalletConnect/QRCode", .exact("14.3.1")),
+    .package(name: "CoinbaseWalletSDK", url: "https://github.com/MobileWalletProtocol/wallet-mobile-sdk", .exact("1.1.2")),
 //    .package(url: "https://github.com/pointfreeco/swift-snapshot-testing", .upToNextMinor(from: "1.10.0")),
 ]
 

--- a/reown-swift.podspec
+++ b/reown-swift.podspec
@@ -66,8 +66,8 @@ spec.pod_target_xcconfig = {
     ss.dependency 'reown-swift/WalletConnectSign'
     ss.dependency 'reown-swift/ReownAppKitUI'
     ss.dependency 'reown-swift/ReownAppKitBackport'
-    ss.dependency 'DSF_QRCode', '~> 16.1.1'
-    ss.dependency 'CoinbaseWalletSDK', '~> 1.1.0'
+    ss.dependency 'DSF_QRCode', '16.1.1'
+    ss.dependency 'CoinbaseWalletSDK', '1.1.2'
     ss.resource_bundles = {
       'ReownAppKit' => [
         'Sources/ReownAppKit/Resources/*'


### PR DESCRIPTION
## Summary

Replaces non-strict version constraints with **exact pins** in the SDK package and podspec, for reproducible builds. Each target matches the version already resolved in `Package.resolved`, so **no resolved version changes** — only the constraints are tightened.

## Changes

**`Package.swift`**
| Dependency | Before | After |
|---|---|---|
| `swift-docc-plugin` | `from: "1.3.0"` | `.exact("1.4.5")` |
| `QRCode` | `from: "14.3.1"` | `.exact("14.3.1")` |
| `CoinbaseWalletSDK` | `.upToNextMinor(from: "1.1.0")` | `.exact("1.1.2")` |

**`reown-swift.podspec`** (dropped the `~>` optimistic operator)
| Dependency | Before | After |
|---|---|---|
| `DSF_QRCode` | `~> 16.1.1` | `16.1.1` |
| `CoinbaseWalletSDK` | `~> 1.1.0` | `1.1.2` |

`yttrium`/`YttriumWrapper` were already exact-pinned, so they're unchanged.

## Scope
- **Sample app (`Example/`) dependencies are intentionally left unchanged** — including the `atlantis`/`SwiftMessages`/`Web3.swift` ranges and the branch-tracking deps (`mixpanel-swift`, `solana-swift`, `HDWallet`).

## Verification
`swift package resolve` succeeds and resolves all three SDK deps to the same versions already in use (`docc 1.4.5`, `QRCode 14.3.1`, `wallet-mobile-sdk 1.1.2`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)