### PR TITLE
test(pay): add USDT-on-Polygon Permit2 Maestro flow support

### DIFF
--- a/.github/workflows/ci_e2e_pay_tests.yml
+++ b/.github/workflows/ci_e2e_pay_tests.yml
@@ -61,8 +61,10 @@ jobs:
             build \
             | xcbeautify
 
+      # TEMP: pinned to the WalletConnect/actions PR #97 head (adds pay_usdt_polygon).
+      # Re-pin to the squash-merge commit on master once #97 lands.
       - name: Copy shared Pay test flows
-        uses: WalletConnect/actions/maestro/pay-tests@3a145abaa0dcf9f609fabe17f6e6722e0db49535 # main
+        uses: WalletConnect/actions/maestro/pay-tests@d07c1f8a83dde5c52b7c8649a6814f98ba716b6b # PR #97 head
 
       - name: Install Maestro
         uses: WalletConnect/actions/maestro/setup@3a145abaa0dcf9f609fabe17f6e6722e0db49535 # main
@@ -99,6 +101,24 @@ jobs:
             --include-tags pay \
             --test-output-dir debug-artifacts/maestro-output \
             .maestro/
+
+      # Reset the USDT Permit2 allowance back to 0 so the next pay_usdt_polygon run
+      # re-exercises the on-chain `approve` step. Runs even when the suite failed
+      # (if: always()) so a mid-flow failure can't leave the allowance set.
+      # continue-on-error so a reset hiccup can't fail an otherwise-green run.
+      # It signs a transaction, so it's a Node step (not a Maestro runScript); the
+      # private key goes via env, never the CLI.
+      # TEMP: pinned to #97 head; re-pin to the master merge commit once #97 lands.
+      - name: Reset USDT Permit2 allowance (Polygon)
+        if: always()
+        continue-on-error: true
+        uses: WalletConnect/actions/maestro/permit2-reset@d07c1f8a83dde5c52b7c8649a6814f98ba716b6b # PR #97 head
+        with:
+          chain-id: eip155:137
+          # polygon-rpc.com gates requests (HTTP 401 "tenant disabled") in CI; use publicnode.
+          rpc-url: https://polygon-bor-rpc.publicnode.com
+          token-address: '0xc2132D05D31c914a87C6611C10748AEb04B58e8F'
+          private-key: ${{ secrets.TEST_WALLET_PRIVATE_KEY }}
 
       - name: Capture simulator logs
         if: always()

--- a/.github/workflows/ci_e2e_pay_tests.yml
+++ b/.github/workflows/ci_e2e_pay_tests.yml
@@ -61,13 +61,11 @@ jobs:
             build \
             | xcbeautify
 
-      # TEMP: pinned to the WalletConnect/actions PR #97 head (adds pay_usdt_polygon).
-      # Re-pin to the squash-merge commit on master once #97 lands.
       - name: Copy shared Pay test flows
-        uses: WalletConnect/actions/maestro/pay-tests@d07c1f8a83dde5c52b7c8649a6814f98ba716b6b # PR #97 head
+        uses: WalletConnect/actions/maestro/pay-tests@3fd66ca1de3848a089d8e3c628e6f54bfcfd999f # main
 
       - name: Install Maestro
-        uses: WalletConnect/actions/maestro/setup@3a145abaa0dcf9f609fabe17f6e6722e0db49535 # main
+        uses: WalletConnect/actions/maestro/setup@3fd66ca1de3848a089d8e3c628e6f54bfcfd999f # main
         with:
           version: '2.4.0'
 
@@ -108,11 +106,10 @@ jobs:
       # continue-on-error so a reset hiccup can't fail an otherwise-green run.
       # It signs a transaction, so it's a Node step (not a Maestro runScript); the
       # private key goes via env, never the CLI.
-      # TEMP: pinned to #97 head; re-pin to the master merge commit once #97 lands.
       - name: Reset USDT Permit2 allowance (Polygon)
         if: always()
         continue-on-error: true
-        uses: WalletConnect/actions/maestro/permit2-reset@d07c1f8a83dde5c52b7c8649a6814f98ba716b6b # PR #97 head
+        uses: WalletConnect/actions/maestro/permit2-reset@3fd66ca1de3848a089d8e3c628e6f54bfcfd999f # main
         with:
           chain-id: eip155:137
           # polygon-rpc.com gates requests (HTTP 401 "tenant disabled") in CI; use publicnode.

--- a/.github/workflows/e2e_balance_check.yml
+++ b/.github/workflows/e2e_balance_check.yml
@@ -12,6 +12,8 @@ env:
   BASE_RPC: 'https://mainnet.base.org'
   OP_USDC: '0x0b2C639c533813f4Aa9D7837CAf62653d097Ff85'
   OP_RPC: 'https://mainnet.optimism.io'
+  POLYGON_USDT: '0xc2132D05D31c914a87C6611C10748AEb04B58e8F'
+  POLYGON_RPC: 'https://polygon-bor-rpc.publicnode.com'
 
 jobs:
   check-balance:
@@ -112,3 +114,95 @@ jobs:
           env.SLACK_FAUCETBOT_WEBHOOK_URL == ''
         run: |
           echo "::warning::SLACK_FAUCETBOT_WEBHOOK_URL not configured, skipping Optimism USDC alert"
+
+      # USDT on Polygon funds the pay_usdt_polygon Permit2 flow (the actual payment).
+      - name: Check USDT balance on Polygon
+        id: poly_usdt_balance
+        run: |
+          BALANCE=$(cast call --rpc-url "$POLYGON_RPC" "$POLYGON_USDT" \
+            "balanceOf(address)(uint256)" \
+            "${{ vars.TEST_WALLET_ADDRESS }}" | sed 's/\[.*\]//' | tr -d '[:space:]')
+          echo "balance=$BALANCE" >> $GITHUB_OUTPUT
+          BALANCE_HUMAN=$(echo "scale=2; $BALANCE / 1000000" | bc)
+          echo "USDT on Polygon: $BALANCE_HUMAN ($BALANCE raw)"
+
+      - name: Prepare USDT on Polygon alert
+        id: poly_usdt_alert
+        run: |
+          BALANCE="${{ steps.poly_usdt_balance.outputs.balance }}"
+          THRESHOLD="${{ vars.USDT_POLYGON_THRESHOLD_UNITS || '1000000' }}"
+          if [ "$BALANCE" -lt "$THRESHOLD" ]; then
+            BALANCE_HUMAN=$(echo "scale=2; $BALANCE / 1000000" | bc)
+            THRESHOLD_HUMAN=$(echo "scale=2; $THRESHOLD / 1000000" | bc)
+            ALERT_TEXT="[request] Can i have ${THRESHOLD_HUMAN} USDT on Polygon in wallet: \
+              ${{ vars.TEST_WALLET_ADDRESS }}"
+            echo "should_alert=true" >> "$GITHUB_OUTPUT"
+            echo "text=$ALERT_TEXT" >> "$GITHUB_OUTPUT"
+            echo "::warning::$ALERT_TEXT"
+          fi
+
+      - name: Send Slack alert (USDT on Polygon)
+        if: |
+          steps.poly_usdt_alert.outputs.should_alert == 'true' &&
+          env.SLACK_FAUCETBOT_WEBHOOK_URL != ''
+        uses: slackapi/slack-github-action@b0fa283ad8fea605de13dc3f449259339835fc52 # v2.1.0
+        with:
+          webhook: ${{ env.SLACK_FAUCETBOT_WEBHOOK_URL }}
+          webhook-type: incoming-webhook
+          payload: |
+            {
+              "text": "${{ steps.poly_usdt_alert.outputs.text }}"
+            }
+
+      - name: Skip Slack alert (USDT on Polygon - no webhook)
+        if: |
+          steps.poly_usdt_alert.outputs.should_alert == 'true' &&
+          env.SLACK_FAUCETBOT_WEBHOOK_URL == ''
+        run: |
+          echo "::warning::SLACK_FAUCETBOT_WEBHOOK_URL not configured, skipping Polygon USDT alert"
+
+      # Native POL gas on Polygon: needed for both the payment txs (approve + pay)
+      # and the post-test Permit2 allowance-reset tx.
+      - name: Check POL gas balance on Polygon
+        id: poly_pol_balance
+        run: |
+          BALANCE=$(cast balance --rpc-url "$POLYGON_RPC" "${{ vars.TEST_WALLET_ADDRESS }}" | tr -d '[:space:]')
+          echo "balance=$BALANCE" >> $GITHUB_OUTPUT
+          BALANCE_HUMAN=$(echo "scale=6; $BALANCE / 1000000000000000000" | bc)
+          echo "POL on Polygon: $BALANCE_HUMAN ($BALANCE wei)"
+
+      - name: Prepare Polygon POL gas alert
+        id: poly_pol_alert
+        run: |
+          BALANCE="${{ steps.poly_pol_balance.outputs.balance }}"
+          THRESHOLD="${{ vars.POLYGON_POL_THRESHOLD_WEI || '1000000000000000000' }}"
+          # Use bc for the comparison: wei values overflow shell arithmetic.
+          if [ "$(echo "$BALANCE < $THRESHOLD" | bc)" -eq 1 ]; then
+            BALANCE_HUMAN=$(echo "scale=6; $BALANCE / 1000000000000000000" | bc)
+            THRESHOLD_HUMAN=$(echo "scale=6; $THRESHOLD / 1000000000000000000" | bc)
+            ALERT_TEXT="[request] Can i have ${THRESHOLD_HUMAN} POL (gas) on Polygon in wallet: \
+              ${{ vars.TEST_WALLET_ADDRESS }} (currently ${BALANCE_HUMAN})"
+            echo "should_alert=true" >> "$GITHUB_OUTPUT"
+            echo "text=$ALERT_TEXT" >> "$GITHUB_OUTPUT"
+            echo "::warning::$ALERT_TEXT"
+          fi
+
+      - name: Send Slack alert (Polygon POL gas)
+        if: |
+          steps.poly_pol_alert.outputs.should_alert == 'true' &&
+          env.SLACK_FAUCETBOT_WEBHOOK_URL != ''
+        uses: slackapi/slack-github-action@b0fa283ad8fea605de13dc3f449259339835fc52 # v2.1.0
+        with:
+          webhook: ${{ env.SLACK_FAUCETBOT_WEBHOOK_URL }}
+          webhook-type: incoming-webhook
+          payload: |
+            {
+              "text": "${{ steps.poly_pol_alert.outputs.text }}"
+            }
+
+      - name: Skip Slack alert (Polygon POL gas - no webhook)
+        if: |
+          steps.poly_pol_alert.outputs.should_alert == 'true' &&
+          env.SLACK_FAUCETBOT_WEBHOOK_URL == ''
+        run: |
+          echo "::warning::SLACK_FAUCETBOT_WEBHOOK_URL not configured, skipping Polygon POL gas alert"

--- a/.github/workflows/e2e_balance_check.yml
+++ b/.github/workflows/e2e_balance_check.yml
@@ -134,7 +134,7 @@ jobs:
           if [ "$BALANCE" -lt "$THRESHOLD" ]; then
             BALANCE_HUMAN=$(echo "scale=2; $BALANCE / 1000000" | bc)
             THRESHOLD_HUMAN=$(echo "scale=2; $THRESHOLD / 1000000" | bc)
-            ALERT_TEXT="[request] Can i have ${THRESHOLD_HUMAN} USDT on Polygon in wallet: \
+            ALERT_TEXT="[request] Can i have ${THRESHOLD_HUMAN} USDT0 on Polygon in wallet: \
               ${{ vars.TEST_WALLET_ADDRESS }}"
             echo "should_alert=true" >> "$GITHUB_OUTPUT"
             echo "text=$ALERT_TEXT" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/e2e_balance_check.yml
+++ b/.github/workflows/e2e_balance_check.yml
@@ -131,7 +131,8 @@ jobs:
         run: |
           BALANCE="${{ steps.poly_usdt_balance.outputs.balance }}"
           THRESHOLD="${{ vars.USDT_POLYGON_THRESHOLD_UNITS || '1000000' }}"
-          if [ "$BALANCE" -lt "$THRESHOLD" ]; then
+          # Use bc for the comparison: a uint256 balance can overflow shell arithmetic.
+          if [ "$(echo "$BALANCE < $THRESHOLD" | bc)" -eq 1 ]; then
             BALANCE_HUMAN=$(echo "scale=2; $BALANCE / 1000000" | bc)
             THRESHOLD_HUMAN=$(echo "scale=2; $THRESHOLD / 1000000" | bc)
             ALERT_TEXT="[request] Can i have ${THRESHOLD_HUMAN} USDT0 on Polygon in wallet: \

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -72,3 +72,13 @@ Both are passed via xcodebuild build settings — no Xcode project changes neede
 All Pay UI views have accessibility identifiers matching the shared Maestro test flows (e.g., `pay-button-pay`, `pay-option-0-selected`, `pay-result-success-icon`). These IDs must stay in sync with `WalletConnect/actions/maestro/pay-tests`.
 
 Important: for custom SwiftUI `Shape`/wrapper content, putting `.accessibilityIdentifier(...)` on an arbitrary SwiftUI container is not always enough for Maestro/XCUITest on iOS. The Pay result icons and KYC badge had to be exposed on underlying native accessible elements (`UIImageView` / `UILabel`) before Maestro could reliably find them. If a visible element is failing by `id`, verify the identifier is attached to the actual native accessibility element, not just a SwiftUI wrapper.
+
+#### Stable option ids (`pay-option-{symbol}-{network}`)
+
+Payment-option rows carry both the order-dependent `pay-option-{index}` (on the row button) and a stable `pay-option-{assetSymbol}-{networkName}` id — lowercased, whitespace → `-` (e.g. `pay-option-usdt-polygon`) — so a flow can pick a specific asset+network when the same token appears on multiple networks. The stable id is exposed via a non-interactive native `MaestroAccessibilityMarker` overlay (`PayOptionItem.swift`); the tap falls through to the row button beneath. The `pay-review-token-{networkName}` id and the row's copyable accessibility label are both **lowercased** so the shared `pay_multiple_options_nokyc` flow (which copies the row label and asserts `pay-review-token-${copiedText}`) stays consistent with the hardcoded lowercase ids used by `pay_usdt_polygon`.
+
+#### USDT-on-Polygon Permit2 flow (`pay_usdt_polygon`)
+
+USDT on Polygon is a plain ERC-20, so WC Pay uses the Permit2 path: the wallet sends an on-chain `approve` then the payment tx. While setting a token up for the first time (allowance 0), `PayConfirmingView` shows the setup note under id `pay-loading-setup-note` (the flow observes it best-effort). CI resets the Permit2 allowance back to 0 after the suite (`Reset USDT Permit2 allowance (Polygon)` step in `ci_e2e_pay_tests.yml`, via the shared `WalletConnect/actions/maestro/permit2-reset` action) so each run re-exercises `approve`; `e2e_balance_check.yml` monitors USDT + POL (gas) on Polygon. The test wallet must hold USDT **and** a little POL on Polygon.
+
+> The `pay-tests` and `permit2-reset` actions are temporarily pinned to the [actions#97](https://github.com/WalletConnect/actions/pull/97) head SHA (`d07c1f8a…`). Re-pin both to the master merge commit once #97 lands.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -80,5 +80,3 @@ Payment-option rows carry both the order-dependent `pay-option-{index}` (on the 
 #### USDT-on-Polygon Permit2 flow (`pay_usdt_polygon`)
 
 USDT on Polygon is a plain ERC-20, so WC Pay uses the Permit2 path: the wallet sends an on-chain `approve` then the payment tx. While setting a token up for the first time (allowance 0), `PayConfirmingView` shows the setup note under id `pay-loading-setup-note` (the flow observes it best-effort). CI resets the Permit2 allowance back to 0 after the suite (`Reset USDT Permit2 allowance (Polygon)` step in `ci_e2e_pay_tests.yml`, via the shared `WalletConnect/actions/maestro/permit2-reset` action) so each run re-exercises `approve`; `e2e_balance_check.yml` monitors USDT + POL (gas) on Polygon. The test wallet must hold USDT **and** a little POL on Polygon.
-
-> The `pay-tests` and `permit2-reset` actions are temporarily pinned to the [actions#97](https://github.com/WalletConnect/actions/pull/97) head SHA (`d07c1f8a…`). Re-pin both to the master merge commit once #97 lands.

--- a/Example/ExampleApp.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Example/ExampleApp.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -123,8 +123,8 @@
         "repositoryURL": "https://github.com/apple/swift-docc-plugin",
         "state": {
           "branch": null,
-          "revision": "85e4bb4e1cd62cec64a4b8e769dcefdf0c5b9d64",
-          "version": "1.4.3"
+          "revision": "3e4f133a77e644a5812911a0513aeb7288b07d06",
+          "version": "1.4.5"
         }
       },
       {

--- a/Example/WalletApp/PresentationLayer/Wallet/Pay/PayConfirmingView.swift
+++ b/Example/WalletApp/PresentationLayer/Wallet/Pay/PayConfirmingView.swift
@@ -28,7 +28,7 @@ struct PayConfirmingView: View {
                         .appFont(.lg)
                         .foregroundColor(AppColors.textSecondary)
                         .multilineTextAlignment(.center)
-                        .accessibilityIdentifier("pay-loading-message-subtitle")
+                        .accessibilityIdentifier("pay-loading-setup-note")
                 }
             }
             .padding(.horizontal, Spacing._5)

--- a/Example/WalletApp/PresentationLayer/Wallet/Pay/PayOptionItem.swift
+++ b/Example/WalletApp/PresentationLayer/Wallet/Pay/PayOptionItem.swift
@@ -189,7 +189,9 @@ struct MaestroAccessibilityMarker: UIViewRepresentable {
         view.isUserInteractionEnabled = false
         view.backgroundColor = .clear
         view.isAccessibilityElement = true
-        view.accessibilityTraits = .button
+        // No trait: this element only exposes a stable id for UI tests; it isn't
+        // interactive (the tap falls through to the row button), so a `.button`
+        // trait would advertise a VoiceOver action that doesn't exist here.
         view.accessibilityIdentifier = identifier
         return view
     }

--- a/Example/WalletApp/PresentationLayer/Wallet/Pay/PayOptionItem.swift
+++ b/Example/WalletApp/PresentationLayer/Wallet/Pay/PayOptionItem.swift
@@ -97,7 +97,7 @@ struct OptionItem: View {
     }
 
     private var rowAccessibilityLabel: String {
-        option.amount.display.networkName ?? "unknown"
+        (option.amount.display.networkName ?? "unknown").lowercased()
     }
 
     private var trailingAccessoryWidth: CGFloat {
@@ -149,6 +149,53 @@ struct OptionItem: View {
         .background(bgColor)
         .cornerRadius(AppRadius._4)
         .contentShape(Rectangle())
+    }
+}
+
+// MARK: - Stable option accessibility id
+
+extension PaymentOption {
+    /// Stable, network+token-keyed id segment for Maestro selection
+    /// (e.g. `usdt-polygon`): `assetSymbol-networkName`, lowercased with
+    /// whitespace collapsed to dashes. Mirrors the RN consumer
+    /// (react-native-examples #533) so the shared `pay_usdt_polygon` flow can
+    /// pick a specific asset+network when a token appears on several networks.
+    var stableOptionIdSuffix: String {
+        let symbol = amount.display.assetSymbol
+        let network = amount.display.networkName ?? "unknown"
+        return "\(symbol)-\(network)"
+            .lowercased()
+            .replacingOccurrences(of: "\\s+", with: "-", options: .regularExpression)
+    }
+}
+
+// MARK: - Maestro accessibility marker
+
+/// Non-interactive native accessibility element used to give a SwiftUI view an
+/// *additional* Maestro-addressable id. Overlaid on a payment-option row, it
+/// exposes the stable `pay-option-{symbol}-{network}` id alongside the
+/// order-dependent `pay-option-{index}` carried by the row button itself.
+///
+/// It doesn't consume touches (`isUserInteractionEnabled = false`), so Maestro's
+/// tap at the marker's frame centre falls through to the row button beneath —
+/// the same effect as RN's outer `<View testID=…>` wrapper. A plain SwiftUI
+/// `.accessibilityIdentifier(...)` on a wrapper isn't reliably surfaced to
+/// XCUITest (see CLAUDE.md), so we back it with a real `UIView`.
+struct MaestroAccessibilityMarker: UIViewRepresentable {
+    let identifier: String
+
+    func makeUIView(context: Context) -> UIView {
+        let view = UIView()
+        view.isUserInteractionEnabled = false
+        view.backgroundColor = .clear
+        view.isAccessibilityElement = true
+        view.accessibilityTraits = .button
+        view.accessibilityIdentifier = identifier
+        return view
+    }
+
+    func updateUIView(_ view: UIView, context: Context) {
+        view.accessibilityIdentifier = identifier
     }
 }
 

--- a/Example/WalletApp/PresentationLayer/Wallet/Pay/PayOptionsView.swift
+++ b/Example/WalletApp/PresentationLayer/Wallet/Pay/PayOptionsView.swift
@@ -56,6 +56,12 @@ struct PayOptionsView: View {
                                 presenter.continueFromOptions()
                             }
                         )
+                        .overlay(
+                            MaestroAccessibilityMarker(
+                                identifier: "pay-option-\(option.stableOptionIdSuffix)"
+                            )
+                            .allowsHitTesting(false)
+                        )
                     }
                 }
             }

--- a/Example/WalletApp/PresentationLayer/Wallet/Pay/PaySummaryView.swift
+++ b/Example/WalletApp/PresentationLayer/Wallet/Pay/PaySummaryView.swift
@@ -48,7 +48,7 @@ struct PaySummaryView: View {
                         option: option,
                         feeState: requiresApprovalForSelected ? presenter.fee(for: option) : .notRequired,
                         rightSlot: rightSlot,
-                        accessibilityId: "pay-review-token-\(option.amount.display.networkName ?? "unknown")"
+                        accessibilityId: "pay-review-token-\((option.amount.display.networkName ?? "unknown").lowercased())"
                     )
                     .padding(.top, Spacing._6)
                 }


### PR DESCRIPTION
# Description

Wires the Swift wallet sample app to the shared `pay_usdt_polygon` Maestro flow (depends on WalletConnect/actions#97), which exercises the two-tx Permit2 `approve` + `pay` path that plain-ERC-20 USDT on Polygon requires. On the app side this exposes stable `pay-option-{symbol}-{network}` ids (e.g. `pay-option-usdt-polygon`) via a non-interactive native accessibility overlay additive to `pay-option-{index}`, renames the setup-note id to `pay-loading-setup-note`, and lowercases the `pay-review-token-{network}` id plus the option row's copyable label so the flow's hardcoded lowercase ids match while keeping the existing multi-options `copyText` flows consistent. CI is wired to pin `pay-tests`/`permit2-reset` to the #97 head (temporary — re-pin to the master merge commit once #97 lands), reset the USDT Permit2 allowance to 0 after each run so the `approve` step is always re-exercised, and monitor USDT + POL (gas) on Polygon in the balance check. Docs in `CLAUDE.md` describe the flow, the id conventions, and the temporary pins.

Resolves # (n/a)

## How Has This Been Tested?

`WalletApp` builds cleanly (`xcodebuild ... -scheme WalletApp build` → BUILD SUCCEEDED). The end-to-end Maestro flow itself runs in CI (`Maestro E2E Pay Tests`) once actions#97 merges and the test wallet is funded with USDT + a little POL on Polygon; locally it can be run with `./scripts/setup-maestro-pay-tests.sh d07c1f8a83dde5c52b7c8649a6814f98ba716b6b` then `./scripts/run-maestro-pay-tests.sh --include-tags pay-usdt-polygon .maestro/`.

## Due Dilligence

* [ ] Breaking change
* [x] Requires a documentation update