### PR TITLE
chore(deps): bump yttrium 0.10.54 → 0.10.57

### DIFF
--- a/Example/ExampleApp.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Example/ExampleApp.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -303,8 +303,8 @@
         "repositoryURL": "https://github.com/reown-com/yttrium",
         "state": {
           "branch": null,
-          "revision": "be6a7252c93ed974bf2f7da9234221339f623aaa",
-          "version": "0.10.54"
+          "revision": "e2175fd8456599f18acc7e9a7bf29d5d534f7232",
+          "version": "0.10.57"
         }
       }
     ]

--- a/Package.resolved
+++ b/Package.resolved
@@ -60,8 +60,8 @@
         "repositoryURL": "https://github.com/reown-com/yttrium",
         "state": {
           "branch": null,
-          "revision": "be6a7252c93ed974bf2f7da9234221339f623aaa",
-          "version": "0.10.54"
+          "revision": "e2175fd8456599f18acc7e9a7bf29d5d534f7232",
+          "version": "0.10.57"
         }
       }
     ]

--- a/Package.swift
+++ b/Package.swift
@@ -17,7 +17,7 @@ var dependencies: [Package.Dependency] = [
 if yttriumDebug {
     dependencies.append(.package(path: "../yttrium"))
 } else {
-    dependencies.append(.package(url: "https://github.com/reown-com/yttrium", .exact("0.10.54")))
+    dependencies.append(.package(url: "https://github.com/reown-com/yttrium", .exact("0.10.57")))
 }
 
 let yttriumTarget = buildYttriumWrapperTarget()


### PR DESCRIPTION
## Summary

Updates the WC Pay **yttrium** dependency to the latest Swift release.

| | Before | After |
|---|---|---|
| Version | `0.10.54` | `0.10.57` |
| Revision | `be6a7252…` | `e2175fd8…` |

`0.10.57` is the latest `YttriumUtils` (Swift) release. `0.10.58` is Kotlin-only, so it is not applicable here.

## Changes
- `Package.swift` — exact pin bumped to `0.10.57`
- `Package.resolved` (root) — version + revision synced
- `Example/…/swiftpm/Package.resolved` (Xcode workspace) — version + revision synced

## Verification
`swift package resolve` succeeds and fetches both binary artifacts for 0.10.57:
- `libyttrium.xcframework.zip`
- `libyttrium-utils.xcframework.zip`

🤖 Generated with [Claude Code](https://claude.com/claude-code)