### PR TITLE
ci(pay): move daily E2E pay tests cron to 04:00 UTC

### DIFF
--- a/.github/workflows/ci_e2e_pay_tests.yml
+++ b/.github/workflows/ci_e2e_pay_tests.yml
@@ -6,8 +6,8 @@ on:
       - develop
       - main
   schedule:
-    # Run daily at 06:00 UTC (only on the default branch)
-    - cron: '0 6 * * *'
+    # Run daily at 04:00 UTC (only on the default branch)
+    - cron: '0 4 * * *'
   workflow_dispatch: {}
 
 permissions:


### PR DESCRIPTION
## What

Moves the daily Maestro E2E Pay test schedule 2 hours earlier, from `0 6 * * *` (06:00 UTC) to `0 4 * * *` (04:00 UTC).

## Why

Requested to shift the daily run earlier.

While here, confirmed the balance check is already wired the same way as the Kotlin repo — the `check-balance` job in `ci_e2e_pay_tests.yml` invokes `e2e_balance_check.yml` via `workflow_call`, and `e2e_balance_check.yml` has no schedule of its own. So the balance check already runs whenever the pay tests run (PR / cron / manual dispatch), and no separate schedule needed removing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)