### PR TITLE
ci(maestro): bump WalletConnect/actions for redesigned /collect IC form

### DIFF
--- a/.github/workflows/ci_e2e_pay_tests.yml
+++ b/.github/workflows/ci_e2e_pay_tests.yml
@@ -62,10 +62,10 @@ jobs:
             | xcbeautify
 
       - name: Copy shared Pay test flows
-        uses: WalletConnect/actions/maestro/pay-tests@3fd66ca1de3848a089d8e3c628e6f54bfcfd999f # main
+        uses: WalletConnect/actions/maestro/pay-tests@a6436dfbb6404e7c086b24054821eb8efcc41b22 # provisional — re-pin to merged-master SHA of WalletConnect/actions#106 before merge
 
       - name: Install Maestro
-        uses: WalletConnect/actions/maestro/setup@3fd66ca1de3848a089d8e3c628e6f54bfcfd999f # main
+        uses: WalletConnect/actions/maestro/setup@a6436dfbb6404e7c086b24054821eb8efcc41b22 # provisional — re-pin to merged-master SHA of WalletConnect/actions#106 before merge
         with:
           version: '2.4.0'
 
@@ -109,7 +109,7 @@ jobs:
       - name: Reset USDT Permit2 allowance (Polygon)
         if: always()
         continue-on-error: true
-        uses: WalletConnect/actions/maestro/permit2-reset@3fd66ca1de3848a089d8e3c628e6f54bfcfd999f # main
+        uses: WalletConnect/actions/maestro/permit2-reset@a6436dfbb6404e7c086b24054821eb8efcc41b22 # provisional — re-pin to merged-master SHA of WalletConnect/actions#106 before merge
         with:
           chain-id: eip155:137
           # polygon-rpc.com gates requests (HTTP 401 "tenant disabled") in CI; use publicnode.

--- a/.github/workflows/ci_e2e_pay_tests.yml
+++ b/.github/workflows/ci_e2e_pay_tests.yml
@@ -70,10 +70,10 @@ jobs:
             | xcbeautify
 
       - name: Copy shared Pay test flows
-        uses: WalletConnect/actions/maestro/pay-tests@bb4ed7054daa7810f387bf307b42c5d4a1efb2da # provisional — re-pin to merged-master SHA of WalletConnect/actions#106 before merge
+        uses: WalletConnect/actions/maestro/pay-tests@bb0d5b1f7acf76a8681444f5ccb094730a1912b2 # provisional — re-pin to merged-master SHA of WalletConnect/actions#106 before merge
 
       - name: Install Maestro
-        uses: WalletConnect/actions/maestro/setup@bb4ed7054daa7810f387bf307b42c5d4a1efb2da # provisional — re-pin to merged-master SHA of WalletConnect/actions#106 before merge
+        uses: WalletConnect/actions/maestro/setup@bb0d5b1f7acf76a8681444f5ccb094730a1912b2 # provisional — re-pin to merged-master SHA of WalletConnect/actions#106 before merge
         with:
           version: '2.4.0'
 
@@ -134,7 +134,7 @@ jobs:
       - name: Reset USDT Permit2 allowance (Polygon)
         if: always()
         continue-on-error: true
-        uses: WalletConnect/actions/maestro/permit2-reset@bb4ed7054daa7810f387bf307b42c5d4a1efb2da # provisional — re-pin to merged-master SHA of WalletConnect/actions#106 before merge
+        uses: WalletConnect/actions/maestro/permit2-reset@bb0d5b1f7acf76a8681444f5ccb094730a1912b2 # provisional — re-pin to merged-master SHA of WalletConnect/actions#106 before merge
         with:
           chain-id: eip155:137
           # polygon-rpc.com gates requests (HTTP 401 "tenant disabled") in CI; use publicnode.

--- a/.github/workflows/ci_e2e_pay_tests.yml
+++ b/.github/workflows/ci_e2e_pay_tests.yml
@@ -62,10 +62,10 @@ jobs:
             | xcbeautify
 
       - name: Copy shared Pay test flows
-        uses: WalletConnect/actions/maestro/pay-tests@a6436dfbb6404e7c086b24054821eb8efcc41b22 # provisional — re-pin to merged-master SHA of WalletConnect/actions#106 before merge
+        uses: WalletConnect/actions/maestro/pay-tests@bb4ed7054daa7810f387bf307b42c5d4a1efb2da # provisional — re-pin to merged-master SHA of WalletConnect/actions#106 before merge
 
       - name: Install Maestro
-        uses: WalletConnect/actions/maestro/setup@a6436dfbb6404e7c086b24054821eb8efcc41b22 # provisional — re-pin to merged-master SHA of WalletConnect/actions#106 before merge
+        uses: WalletConnect/actions/maestro/setup@bb4ed7054daa7810f387bf307b42c5d4a1efb2da # provisional — re-pin to merged-master SHA of WalletConnect/actions#106 before merge
         with:
           version: '2.4.0'
 
@@ -109,7 +109,7 @@ jobs:
       - name: Reset USDT Permit2 allowance (Polygon)
         if: always()
         continue-on-error: true
-        uses: WalletConnect/actions/maestro/permit2-reset@a6436dfbb6404e7c086b24054821eb8efcc41b22 # provisional — re-pin to merged-master SHA of WalletConnect/actions#106 before merge
+        uses: WalletConnect/actions/maestro/permit2-reset@bb4ed7054daa7810f387bf307b42c5d4a1efb2da # provisional — re-pin to merged-master SHA of WalletConnect/actions#106 before merge
         with:
           chain-id: eip155:137
           # polygon-rpc.com gates requests (HTTP 401 "tenant disabled") in CI; use publicnode.

--- a/.github/workflows/ci_e2e_pay_tests.yml
+++ b/.github/workflows/ci_e2e_pay_tests.yml
@@ -70,10 +70,10 @@ jobs:
             | xcbeautify
 
       - name: Copy shared Pay test flows
-        uses: WalletConnect/actions/maestro/pay-tests@bb0d5b1f7acf76a8681444f5ccb094730a1912b2 # provisional — re-pin to merged-master SHA of WalletConnect/actions#106 before merge
+        uses: WalletConnect/actions/maestro/pay-tests@27c02b08f4659e67c95679097fa0e34dffd413ec # provisional — re-pin to merged-master SHA of WalletConnect/actions#106 before merge
 
       - name: Install Maestro
-        uses: WalletConnect/actions/maestro/setup@bb0d5b1f7acf76a8681444f5ccb094730a1912b2 # provisional — re-pin to merged-master SHA of WalletConnect/actions#106 before merge
+        uses: WalletConnect/actions/maestro/setup@27c02b08f4659e67c95679097fa0e34dffd413ec # provisional — re-pin to merged-master SHA of WalletConnect/actions#106 before merge
         with:
           version: '2.4.0'
 
@@ -134,7 +134,7 @@ jobs:
       - name: Reset USDT Permit2 allowance (Polygon)
         if: always()
         continue-on-error: true
-        uses: WalletConnect/actions/maestro/permit2-reset@bb0d5b1f7acf76a8681444f5ccb094730a1912b2 # provisional — re-pin to merged-master SHA of WalletConnect/actions#106 before merge
+        uses: WalletConnect/actions/maestro/permit2-reset@27c02b08f4659e67c95679097fa0e34dffd413ec # provisional — re-pin to merged-master SHA of WalletConnect/actions#106 before merge
         with:
           chain-id: eip155:137
           # polygon-rpc.com gates requests (HTTP 401 "tenant disabled") in CI; use publicnode.

--- a/.github/workflows/ci_e2e_pay_tests.yml
+++ b/.github/workflows/ci_e2e_pay_tests.yml
@@ -70,10 +70,10 @@ jobs:
             | xcbeautify
 
       - name: Copy shared Pay test flows
-        uses: WalletConnect/actions/maestro/pay-tests@27c02b08f4659e67c95679097fa0e34dffd413ec # provisional — re-pin to merged-master SHA of WalletConnect/actions#106 before merge
+        uses: WalletConnect/actions/maestro/pay-tests@ddc7c0f9acd8b1576e9a78f0ef67f4b8fbb36db2
 
       - name: Install Maestro
-        uses: WalletConnect/actions/maestro/setup@27c02b08f4659e67c95679097fa0e34dffd413ec # provisional — re-pin to merged-master SHA of WalletConnect/actions#106 before merge
+        uses: WalletConnect/actions/maestro/setup@ddc7c0f9acd8b1576e9a78f0ef67f4b8fbb36db2
         with:
           version: '2.4.0'
 
@@ -134,7 +134,7 @@ jobs:
       - name: Reset USDT Permit2 allowance (Polygon)
         if: always()
         continue-on-error: true
-        uses: WalletConnect/actions/maestro/permit2-reset@27c02b08f4659e67c95679097fa0e34dffd413ec # provisional — re-pin to merged-master SHA of WalletConnect/actions#106 before merge
+        uses: WalletConnect/actions/maestro/permit2-reset@ddc7c0f9acd8b1576e9a78f0ef67f4b8fbb36db2
         with:
           chain-id: eip155:137
           # polygon-rpc.com gates requests (HTTP 401 "tenant disabled") in CI; use publicnode.


### PR DESCRIPTION
## Bump `WalletConnect/actions` maestro refs for the redesigned `/collect` IC form

`WalletConnect/buyer-experience` PR #914 redesigns the hosted KYC webview (the `/collect` route the sample wallet opens in a WebView). The native Maestro `pay` flows drive that webview by visible text, so they were updated in **WalletConnect/actions#106** (submit is now "Confirm", the "Confirm your details" dialog is gone, and consent is an inline "I agree" checkbox). The verified KYC sequence is: scroll to **"I agree"** → tap it → scroll to **"Confirm"** → tap it.

This PR pins every `WalletConnect/actions/maestro/*` ref (pay-tests / setup / permit2-reset) to the merged-master SHA that contains those flow changes.

- Pinned SHA: **`ddc7c0f9acd8b1576e9a78f0ef67f4b8fbb36db2`** (squash-merge of WalletConnect/actions#106, now `master` tip).

### ✅ Ready to merge — remaining requirement
- WalletConnect/actions#106 is **merged** to master. ✔
- buyer-experience **#914** must be **deployed** to the env this wallet's `/collect` webview loads (prod/staging) before the `pay`-tagged Maestro runs will pass — the flows now expect the redesigned form.

### Validation
Android Maestro `pay` runs were dispatched on this branch against the merged action and exercised the new KYC flow (scroll + tap "I agree", scroll + tap "Confirm").

🤖 Generated with [Claude Code](https://claude.com/claude-code)
