### PR TITLE
ci(pay): boot any available iPhone simulator for iOS E2E

### DIFF
--- a/.github/workflows/ci_e2e_pay_tests.yml
+++ b/.github/workflows/ci_e2e_pay_tests.yml
@@ -51,7 +51,7 @@ jobs:
             xcodebuild \
             -project "Example/ExampleApp.xcodeproj" \
             -scheme "WalletApp" \
-            -destination "platform=iOS Simulator,name=iPhone 16" \
+            -destination "generic/platform=iOS Simulator" \
             -derivedDataPath DerivedDataCache \
             -clonedSourcePackagesDirPath ../SourcePackagesCache \
             RELAY_HOST='relay.walletconnect.com' \
@@ -71,8 +71,19 @@ jobs:
 
       - name: Boot iOS simulator
         run: |
-          xcrun simctl boot "iPhone 16" 2>/dev/null || true
-          xcrun simctl bootstatus "iPhone 16"
+          # Pick whatever iPhone simulator the runner actually has, so this
+          # doesn't break each time the Xcode/runner image bumps the model.
+          SIMULATOR_UDID=$(xcrun simctl list devices available \
+            | grep -Eo 'iPhone[^(]*\([A-Fa-f0-9-]{36}\)' \
+            | grep -Eo '[A-Fa-f0-9-]{36}' | head -n 1)
+          if [ -z "$SIMULATOR_UDID" ]; then
+            echo "ERROR: no available iPhone simulator found"
+            xcrun simctl list devices available
+            exit 1
+          fi
+          echo "Using simulator: $SIMULATOR_UDID"
+          xcrun simctl boot "$SIMULATOR_UDID" 2>/dev/null || true
+          xcrun simctl bootstatus "$SIMULATOR_UDID"
 
       - name: Install app on simulator
         run: |

--- a/.github/workflows/ci_e2e_pay_tests.yml
+++ b/.github/workflows/ci_e2e_pay_tests.yml
@@ -73,9 +73,12 @@ jobs:
         run: |
           # Pick whatever iPhone simulator the runner actually has, so this
           # doesn't break each time the Xcode/runner image bumps the model.
+          # Single awk pass: pull the UDID from the first available iPhone row.
+          # awk exits 0 even when nothing matches (so the check below stays
+          # reachable under `set -eo pipefail`), `exit` avoids a head/SIGPIPE
+          # footgun, and it tolerates parens in the device name (e.g. SE).
           SIMULATOR_UDID=$(xcrun simctl list devices available \
-            | grep -Eo 'iPhone[^(]*\([A-Fa-f0-9-]{36}\)' \
-            | grep -Eo '[A-Fa-f0-9-]{36}' | head -n 1)
+            | awk '/iPhone/ { if (match($0, /[0-9A-Fa-f-]{36}/)) { print substr($0, RSTART, RLENGTH); exit } }')
           if [ -z "$SIMULATOR_UDID" ]; then
             echo "ERROR: no available iPhone simulator found"
             xcrun simctl list devices available
@@ -84,6 +87,9 @@ jobs:
           echo "Using simulator: $SIMULATOR_UDID"
           xcrun simctl boot "$SIMULATOR_UDID" 2>/dev/null || true
           xcrun simctl bootstatus "$SIMULATOR_UDID"
+          # Reset associated-domains state before install so the applinks
+          # (Universal Link) binding isn't wiped from stale simulator state.
+          xcrun simctl spawn booted swcutil reset || true
 
       - name: Install app on simulator
         run: |


### PR DESCRIPTION
## Description

The iOS lane of the Pay E2E workflow hardcoded `iPhone 16` for both the build destination and the simulator boot. On the Xcode 26 / iOS 26 runner (ships iPhone 17-series simulators) that device no longer exists, so the failing job ([run 28312629497](https://github.com/reown-com/reown-swift/actions/runs/28312629497/job/83879992292)) couldn't resolve it.

This change:
- builds with a **generic** simulator destination (`generic/platform=iOS Simulator`) — no named device needed;
- discovers an **available iPhone simulator UDID at runtime** in the boot step via `xcrun simctl list devices available`, failing clearly if none exist.

All later steps already use the `booted` alias / bundle id, so only the build and boot steps needed updating. Keeps the workflow green across future Xcode/runner image bumps.

Mirrors the merged Flutter fix [reown_flutter#389](https://github.com/reown-com/reown_flutter/pull/389).

The cron schedule is intentionally left untouched (already at 04:00 UTC).

## How Has This Been Tested?

CI on this PR (runs on `pull_request`) will confirm — the "Boot iOS simulator" step now prints `Using simulator: <UDID>`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)