### PR TITLE
ci(maestro): drop universal-link (deeplink) support from wallet Pay E2E

### DIFF
--- a/.github/workflows/ci_e2e_pay_tests.yml
+++ b/.github/workflows/ci_e2e_pay_tests.yml
@@ -70,10 +70,10 @@ jobs:
             | xcbeautify
 
       - name: Copy shared Pay test flows
-        uses: WalletConnect/actions/maestro/pay-tests@28181b5f133836380d2d9bb8ff06af5c3234fb9d
+        uses: WalletConnect/actions/maestro/pay-tests@4be7c0112f9651fc63b18c137650b75d2fc9b200
 
       - name: Install Maestro
-        uses: WalletConnect/actions/maestro/setup@28181b5f133836380d2d9bb8ff06af5c3234fb9d
+        uses: WalletConnect/actions/maestro/setup@4be7c0112f9651fc63b18c137650b75d2fc9b200
         with:
           version: '2.4.0'
 
@@ -131,7 +131,7 @@ jobs:
       - name: Reset USDT Permit2 allowance (Polygon)
         if: always()
         continue-on-error: true
-        uses: WalletConnect/actions/maestro/permit2-reset@28181b5f133836380d2d9bb8ff06af5c3234fb9d
+        uses: WalletConnect/actions/maestro/permit2-reset@4be7c0112f9651fc63b18c137650b75d2fc9b200
         with:
           chain-id: eip155:137
           # polygon-rpc.com gates requests (HTTP 401 "tenant disabled") in CI; use publicnode.

--- a/.github/workflows/ci_e2e_pay_tests.yml
+++ b/.github/workflows/ci_e2e_pay_tests.yml
@@ -70,10 +70,10 @@ jobs:
             | xcbeautify
 
       - name: Copy shared Pay test flows
-        uses: WalletConnect/actions/maestro/pay-tests@ddc7c0f9acd8b1576e9a78f0ef67f4b8fbb36db2
+        uses: WalletConnect/actions/maestro/pay-tests@28181b5f133836380d2d9bb8ff06af5c3234fb9d
 
       - name: Install Maestro
-        uses: WalletConnect/actions/maestro/setup@ddc7c0f9acd8b1576e9a78f0ef67f4b8fbb36db2
+        uses: WalletConnect/actions/maestro/setup@28181b5f133836380d2d9bb8ff06af5c3234fb9d
         with:
           version: '2.4.0'
 
@@ -95,9 +95,6 @@ jobs:
           echo "Using simulator: $SIMULATOR_UDID"
           xcrun simctl boot "$SIMULATOR_UDID" 2>/dev/null || true
           xcrun simctl bootstatus "$SIMULATOR_UDID"
-          # Reset associated-domains state before install so the applinks
-          # (Universal Link) binding isn't wiped from stale simulator state.
-          xcrun simctl spawn booted swcutil reset || true
 
       - name: Install app on simulator
         run: |
@@ -134,7 +131,7 @@ jobs:
       - name: Reset USDT Permit2 allowance (Polygon)
         if: always()
         continue-on-error: true
-        uses: WalletConnect/actions/maestro/permit2-reset@ddc7c0f9acd8b1576e9a78f0ef67f4b8fbb36db2
+        uses: WalletConnect/actions/maestro/permit2-reset@28181b5f133836380d2d9bb8ff06af5c3234fb9d
         with:
           chain-id: eip155:137
           # polygon-rpc.com gates requests (HTTP 401 "tenant disabled") in CI; use publicnode.

--- a/Example/WalletApp/ApplicationLayer/SceneDelegate.swift
+++ b/Example/WalletApp/ApplicationLayer/SceneDelegate.swift
@@ -214,6 +214,10 @@ private extension SceneDelegate {
     /// - WC URI format: `uri` parameter containing embedded `pay` param
     /// - Gateway / universal links with `pid` or `paymentId` query params
     /// - App deeplinks with `walletconnectpay?paymentId=...`
+    ///
+    /// Note: `pay.walletconnect.*` universal-link registration was removed from
+    /// the entitlements, so on native these payment URLs now arrive via NFC (or
+    /// the test-mode URL field) rather than a tapped App Link.
     private func extractPaymentLink(from url: URL) -> String? {
         guard let components = URLComponents(url: url, resolvingAgainstBaseURL: false),
               let queryItems = components.queryItems else { return nil }

--- a/Example/WalletApp/WalletApp.entitlements
+++ b/Example/WalletApp/WalletApp.entitlements
@@ -7,9 +7,6 @@
 	<key>com.apple.developer.associated-domains</key>
 	<array>
 		<string>applinks:lab.reown.com</string>
-		<string>applinks:pay.walletconnect.com</string>
-		<string>applinks:staging.pay.walletconnect.com</string>
-		<string>applinks:dev.pay.walletconnect.com</string>
 	</array>
 	<key>com.apple.developer.nfc.readersession.formats</key>
 	<array>

--- a/Example/WalletApp/WalletAppRelease.entitlements
+++ b/Example/WalletApp/WalletAppRelease.entitlements
@@ -7,9 +7,6 @@
 	<key>com.apple.developer.associated-domains</key>
 	<array>
 		<string>applinks:lab.reown.com</string>
-		<string>applinks:pay.walletconnect.com</string>
-		<string>applinks:staging.pay.walletconnect.com</string>
-		<string>applinks:dev.pay.walletconnect.com</string>
 	</array>
 	<key>com.apple.developer.nfc.readersession.formats</key>
 	<array>


### PR DESCRIPTION
# Description

Universal linking is no longer in scope for the wallet Maestro Pay suite — [WalletConnect/actions#109](https://github.com/WalletConnect/actions/pull/109) removes the Universal Link pay test (`pay_single_option_nokyc_deeplink.yaml` + its `pay_open_via_deeplink.yaml` subflow) from the shared suite. This PR strips the infrastructure in this repo that existed **only** to make that test pass. Mirrors [reown-com/react-native-examples#563](https://github.com/reown-com/react-native-examples/pull/563) for the Swift `WalletApp` sample.

Pay links still reach the wallet via **NFC** and the in-app URL text field (test mode) — only the tapped Universal Link (`applinks:pay.walletconnect.*`) path is removed. The `SceneDelegate` payment-link handler is unchanged, and `lab.reown.com` applinks (link mode / dApp deep-link-back) are kept.

### Changes

- **Remove pay hosts from associated domains** (`WalletApp.entitlements`, `WalletAppRelease.entitlements`): drop `applinks:pay.walletconnect.com` / `staging.` / `dev.`, keeping `applinks:lab.reown.com`.
- **Remove the associated-domains cache reset from CI** (`ci_e2e_pay_tests.yml`): drop `xcrun simctl spawn booted swcutil reset` from the simulator-boot step — it only existed to keep the `applinks:` binding alive across install for the UL test.
- **Bump the shared-flow pins** (`ci_e2e_pay_tests.yml`): `pay-tests`, `setup`, `permit2-reset` re-pinned to the 109 **merge commit** `4be7c0112f9651fc63b18c137650b75d2fc9b200` so the deeplink flow is no longer downloaded.
- **Reword the pay-link comment** (`SceneDelegate.swift`): note that these URLs now arrive via NFC / the test-mode URL field rather than a tapped App Link. Handler logic unchanged.

### RN changes with no Swift equivalent (intentionally skipped)

- Signing secrets in the E2E job — our workflow never passed match/Apple signing secrets; the simulator build already uses `ENABLE_TEST_MODE` and is unsigned.
- Android intent filters — no Android target.
- `run-maestro-pay-tests.sh` web-skip entry — our script has no web leg / `WEB_SKIP_FLOWS` list.
- AASA-priming / `swcd` log predicate — never existed in our CI.

## How Has This Been Tested?

- `grep -rn "pay.walletconnect.com" Example/WalletApp/*.entitlements` → no matches (only `applinks:lab.reown.com` remains).
- `grep -rn "swcutil" .github/workflows/` → no matches.
- `grep -c "4be7c0112f9651fc63b18c137650b75d2fc9b200" .github/workflows/ci_e2e_pay_tests.yml` → 3.
- Maestro E2E Pay suite (this workflow) validates end-to-end: the downloaded flow set no longer contains `pay_single_option_nokyc_deeplink`, and the remaining pay flows still pass (NFC / URL-field entry unaffected).

## Due Dilligence

* [ ] Breaking change
* [ ] Requires a documentation update

🤖 Generated with [Claude Code](https://claude.com/claude-code)