### PR TITLE
ci(e2e-pay): boot simulator before build to dodge the "Ready for Apple Intelligence" banner

### DIFF
--- a/.github/workflows/ci_e2e_pay_tests.yml
+++ b/.github/workflows/ci_e2e_pay_tests.yml
@@ -75,9 +75,12 @@ jobs:
           # the item's creationDate matches this key to the second). Pre-seeding
           # it marks the notification as already shown, covering runs where the
           # build finishes (warm SPM cache) before the banner would have fired.
+          # Best-effort: booting early is the primary defense, so a runner image
+          # where this domain isn't writable must not fail the whole run.
           xcrun simctl spawn "$SIMULATOR_UDID" defaults write \
             com.apple.generativeexperiences.corefollowup \
-            DateOfLastAppleIntelligenceReadinessCFU -date "$(date -u '+%Y-%m-%d %H:%M:%S +0000')"
+            DateOfLastAppleIntelligenceReadinessCFU -date "$(date -u '+%Y-%m-%d %H:%M:%S +0000')" \
+            || echo "WARNING: could not pre-seed Apple Intelligence CFU timestamp (non-fatal)"
 
       - uses: actions/cache@v3
         with:

--- a/.github/workflows/ci_e2e_pay_tests.yml
+++ b/.github/workflows/ci_e2e_pay_tests.yml
@@ -46,6 +46,39 @@ jobs:
         with:
           xcode-version: '26'
 
+      # Boot the simulator BEFORE the build (not right before `maestro test`).
+      # A never-booted device posts a one-time "Ready for Apple Intelligence"
+      # follow-up notification a few minutes after its first boot; when the sim
+      # was booted seconds before the tests, that banner landed ~8s into the
+      # first flow, covering the button Maestro was about to tap. Booting early
+      # lets it fire and auto-dismiss during the ~10 min build instead.
+      - name: Boot iOS simulator
+        run: |
+          # Pick whatever iPhone simulator the runner actually has, so this
+          # doesn't break each time the Xcode/runner image bumps the model.
+          # Single awk pass: pull the UDID from the first available iPhone row.
+          # awk exits 0 even when nothing matches (so the check below stays
+          # reachable under `set -eo pipefail`), `exit` avoids a head/SIGPIPE
+          # footgun, and it tolerates parens in the device name (e.g. SE).
+          SIMULATOR_UDID=$(xcrun simctl list devices available \
+            | awk '/iPhone/ { if (match($0, /[0-9A-Fa-f-]{36}/)) { print substr($0, RSTART, RLENGTH); exit } }')
+          if [ -z "$SIMULATOR_UDID" ]; then
+            echo "ERROR: no available iPhone simulator found"
+            xcrun simctl list devices available
+            exit 1
+          fi
+          echo "Using simulator: $SIMULATOR_UDID"
+          xcrun simctl boot "$SIMULATOR_UDID" 2>/dev/null || true
+          xcrun simctl bootstatus "$SIMULATOR_UDID"
+          # Belt and suspenders for the same banner: iOS stamps this key when it
+          # posts the follow-up (verified against a sim's CoreFollowUp items.db —
+          # the item's creationDate matches this key to the second). Pre-seeding
+          # it marks the notification as already shown, covering runs where the
+          # build finishes (warm SPM cache) before the banner would have fired.
+          xcrun simctl spawn "$SIMULATOR_UDID" defaults write \
+            com.apple.generativeexperiences.corefollowup \
+            DateOfLastAppleIntelligenceReadinessCFU -date "$(date -u '+%Y-%m-%d %H:%M:%S +0000')"
+
       - uses: actions/cache@v3
         with:
           path: |
@@ -76,25 +109,6 @@ jobs:
         uses: WalletConnect/actions/maestro/setup@4be7c0112f9651fc63b18c137650b75d2fc9b200
         with:
           version: '2.4.0'
-
-      - name: Boot iOS simulator
-        run: |
-          # Pick whatever iPhone simulator the runner actually has, so this
-          # doesn't break each time the Xcode/runner image bumps the model.
-          # Single awk pass: pull the UDID from the first available iPhone row.
-          # awk exits 0 even when nothing matches (so the check below stays
-          # reachable under `set -eo pipefail`), `exit` avoids a head/SIGPIPE
-          # footgun, and it tolerates parens in the device name (e.g. SE).
-          SIMULATOR_UDID=$(xcrun simctl list devices available \
-            | awk '/iPhone/ { if (match($0, /[0-9A-Fa-f-]{36}/)) { print substr($0, RSTART, RLENGTH); exit } }')
-          if [ -z "$SIMULATOR_UDID" ]; then
-            echo "ERROR: no available iPhone simulator found"
-            xcrun simctl list devices available
-            exit 1
-          fi
-          echo "Using simulator: $SIMULATOR_UDID"
-          xcrun simctl boot "$SIMULATOR_UDID" 2>/dev/null || true
-          xcrun simctl bootstatus "$SIMULATOR_UDID"
 
       - name: Install app on simulator
         run: |


### PR DESCRIPTION
## Problem

E2E pay runs intermittently fail when an iOS system notification — **"Ready for Apple Intelligence"** — pops over the app and swallows the tap Maestro is making underneath it. In the failing run it appeared ~8s into the first test.

## Root cause

That banner is a **one-time device-setup follow-up** (CoreFollowUp item `com.apple.icloud.gm`) that iOS posts a few minutes after a simulator's *first boot*. Every CI run gets a fresh runner VM with a never-booted simulator, and this workflow boots it **after** the ~10 min build, seconds before `maestro test` — so the banner reliably fires mid-test.

## Fix (two independent layers)

1. **Move the "Boot iOS simulator" step before the build.** The banner fires and auto-dismisses (~6-8s) during the build instead of during a test flow. The step itself is unchanged.
2. **Pre-seed `DateOfLastAppleIntelligenceReadinessCFU`** in the `com.apple.generativeexperiences.corefollowup` domain right after boot. iOS stamps this key when it posts the banner — verified against a long-lived simulator where the key's timestamp matches the CoreFollowUp item's `creationDate` to the second — so seeding it marks the notification as already shown. This covers runs where a warm SPM cache makes the build finish before the banner would have fired.

No behavior change for the tests themselves: device selection, install (`simctl install booted`), and the maestro invocation are untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)