### PR TITLE
fix(utils): reject CR/LF in CACAO SIWE single-line fields

### DIFF
--- a/Sources/WalletConnectUtils/SIWE/SIWEFromCacaoPayloadFormatter.swift
+++ b/Sources/WalletConnectUtils/SIWE/SIWEFromCacaoPayloadFormatter.swift
@@ -21,6 +21,10 @@ public typealias SignWithXFormatter = SIWEFromCacaoPayloadFormatter
 /// Previously SIWEFromCacaoPayloadFormatter - now supports Sign with X (CAIP-122)
 public struct SIWEFromCacaoPayloadFormatter: SignWithXFormatting {
 
+    public enum Errors: Error, Equatable {
+        case invalidSingleLineField(String)
+    }
+
     public init() {}
 
     public func formatMessage(from payload: CacaoPayload, includeRecapInTheStatement: Bool) throws -> String {
@@ -29,6 +33,27 @@ public struct SIWEFromCacaoPayloadFormatter: SignWithXFormatting {
         let address = account.address
         let chainId = account.reference
         let namespace = account.namespace
+
+        // EIP-4361 / CAIP-122 single-line fields must not embed CR/LF, or a
+        // caller can forge later lines (URI, Nonce, …). Parity with
+        // walletconnect-monorepo #7311 / walletconnect-utils #280.
+        try assertSingleLine(payload.domain, field: "domain")
+        try assertSingleLine(payload.aud, field: "aud")
+        try assertSingleLine(payload.version, field: "version")
+        try assertSingleLine(payload.nonce, field: "nonce")
+        try assertSingleLine(payload.iat, field: "iat")
+        if let statement = payload.statement {
+            try assertSingleLine(statement, field: "statement")
+        }
+        if let exp = payload.exp {
+            try assertSingleLine(exp, field: "exp")
+        }
+        if let nbf = payload.nbf {
+            try assertSingleLine(nbf, field: "nbf")
+        }
+        if let requestId = payload.requestId {
+            try assertSingleLine(requestId, field: "requestId")
+        }
 
         // Determine chain-specific account type for CAIP-122
         let accountType = getAccountType(for: namespace)
@@ -49,6 +74,12 @@ public struct SIWEFromCacaoPayloadFormatter: SignWithXFormatting {
         Issued At: \(payload.iat)\(formatExpLine(exp: payload.exp))\(formatNbfLine(nbf: payload.nbf))\(formatRequestIdLine(requestId: payload.requestId))\(formatResourcesSection(resources: payload.resources))
         """
         return formattedMessage
+    }
+
+    private func assertSingleLine(_ value: String, field: String) throws {
+        if value.contains("\r") || value.contains("\n") {
+            throw Errors.invalidSingleLineField(field)
+        }
     }
 
     // CAIP-122: Map chain namespace to account type

--- a/Tests/WalletConnectSignTests/SIWEFromCacaoPayloadFormatterTests.swift
+++ b/Tests/WalletConnectSignTests/SIWEFromCacaoPayloadFormatterTests.swift
@@ -289,4 +289,57 @@ class SIWEFromCacaoPayloadFormatterTests: XCTestCase {
         let message = try sut.formatMessage(from: cacaoPayload)
         XCTAssertEqual(message, expectedMessage)
     }
+
+    // MARK: - EIP-4361 single-line field integrity
+
+    func testRejectsDomainWithEmbeddedNewline() throws {
+        let payload = try smugglingPayload(domain: "service.invalid\nURI: https://evil.invalid")
+        XCTAssertThrowsError(try sut.formatMessage(from: payload)) { error in
+            XCTAssertEqual(
+                error as? SIWEFromCacaoPayloadFormatter.Errors,
+                .invalidSingleLineField("domain")
+            )
+        }
+    }
+
+    func testRejectsStatementWithEmbeddedCarriageReturn() throws {
+        let payload = try smugglingPayload(statement: "I accept\rURI: https://evil.invalid")
+        XCTAssertThrowsError(try sut.formatMessage(from: payload)) { error in
+            XCTAssertEqual(
+                error as? SIWEFromCacaoPayloadFormatter.Errors,
+                .invalidSingleLineField("statement")
+            )
+        }
+    }
+
+    func testRejectsAudWithEmbeddedNewline() throws {
+        let payload = try smugglingPayload(aud: "https://service.invalid/login\nNonce: forged")
+        XCTAssertThrowsError(try sut.formatMessage(from: payload)) { error in
+            XCTAssertEqual(
+                error as? SIWEFromCacaoPayloadFormatter.Errors,
+                .invalidSingleLineField("aud")
+            )
+        }
+    }
+
+    private func smugglingPayload(
+        domain: String = "service.invalid",
+        aud: String = "https://service.invalid/login",
+        statement: String? = "I accept the ServiceOrg Terms of Service: https://service.invalid/tos"
+    ) throws -> CacaoPayload {
+        let account = Account.stub()
+        return CacaoPayload(
+            iss: account.did,
+            domain: domain,
+            aud: aud,
+            version: "1",
+            nonce: "32891756",
+            iat: "2021-09-30T16:25:24Z",
+            nbf: nil,
+            exp: nil,
+            statement: statement,
+            requestId: nil,
+            resources: nil
+        )
+    }
 }


### PR DESCRIPTION
# Description

`SIWEFromCacaoPayloadFormatter.formatMessage` interpolated CACAO `domain` / `statement` / `aud` / `version` / `nonce` / `iat` / optional `exp` / `nbf` / `requestId` into the EIP-4361 (CAIP-122) message without rejecting embedded `\r` / `\n`.

A crafted `domain` like `example.com\nURI: https://evil.example` forges additional message lines (same class as statement smuggling).

Fail closed: reject CR/LF in those single-line fields before formatting. Sibling of walletconnect-monorepo#7311 and walletconnect-utils#280.

Resolves # (issue) n/a (hardening)

## How Has This Been Tested?

* Added unit tests that assert domain / statement / aud with embedded breaks throw `invalidSingleLineField`
* Existing formatter fixtures unchanged
* Full `swift test` not run locally (SwiftPM yttrium binary download blocked here); CI is the gate

## Due Dilligence

* [ ] Breaking change (callers that previously smuggled line breaks into single-line fields will now throw)
* [ ] Requires a documentation update

## Attacker model

Party that supplies CACAO payload fields used for sign/verify message reconstruction (malicious or compromised auth-request builder). No private key required. Gap is structured-field to SIWE-text integrity.


Made with [Cursor](https://cursor.com)